### PR TITLE
execfile() was removed in Python 3 for security reasons

### DIFF
--- a/tensorflow_hub/pip_package/setup.py
+++ b/tensorflow_hub/pip_package/setup.py
@@ -22,7 +22,8 @@ from setuptools import setup
 
 # Can't import the module during setup.py.
 # Use execfile to find __version__.
-execfile("tensorflow_hub/version.py")
+with open("tensorflow_hub/version.py") as in_file:
+    exec(in_file.read())
 
 REQUIRED_PACKAGES = [
     'numpy >= 1.12.0',


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.0.html#builtins