### PR TITLE
Add bottleneck cache when enabling distortions

### DIFF
--- a/examples/image_retraining/retrain.py
+++ b/examples/image_retraining/retrain.py
@@ -1039,6 +1039,10 @@ def main(_):
        distorted_image_tensor) = add_input_distortions(
            FLAGS.flip_left_right, FLAGS.random_crop, FLAGS.random_scale,
            FLAGS.random_brightness, module_spec)
+      cache_bottlenecks(sess, image_lists, FLAGS.image_dir,
+                        FLAGS.bottleneck_dir, distorted_jpeg_data_tensor,
+                        distorted_image_tensor, resized_image_tensor,
+                        bottleneck_tensor, FLAGS.tfhub_module)
     else:
       # We'll make sure we've calculated the 'bottleneck' image summaries and
       # cached them on disk.


### PR DESCRIPTION
When doing distortions, bottlenecks are not cached and results into the following error. This commit fixes it. Bug reported by @jdb2438 and @craymichael.

```
2018-04-08 03:55:44.085420: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1423] Adding visible gpu devices: 0
2018-04-08 03:55:44.085528: I tensorflow/core/common_runtime/gpu/gpu_device.cc:911] Device interconnect StreamExecutor with strength 1 edge matrix:
2018-04-08 03:55:44.085727: I tensorflow/core/common_runtime/gpu/gpu_device.cc:917]      0 
2018-04-08 03:55:44.085949: I tensorflow/core/common_runtime/gpu/gpu_device.cc:930] 0:   N 
2018-04-08 03:55:44.086201: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1041] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 10
751 MB memory) -> physical GPU (device: 0, name: Tesla K80, pci bus id: 0000:00:04.0, compute capability: 3.7)
INFO:tensorflow:Restoring parameters from /tmp/_retrain_checkpoint
INFO:tensorflow:Creating bottleneck at /tmp/bottleneck/cat/cat.333.jpg_https~tfhub.dev~google~imagenet~mobilenet_v2_100_224~feature_vector~1.txt
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/client/session.py", line 1080, in _run
    subfeed, allow_tensor=True, allow_operation=False)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/framework/ops.py", line 3478, in as_graph_element
    return self._as_graph_element_locked(obj, allow_tensor, allow_operation)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/framework/ops.py", line 3557, in _as_graph_element_locked
    raise ValueError("Tensor %s is not an element of this graph." % obj)
ValueError: Tensor Tensor("DecodeJPGInput:0", dtype=string) is not an element of this graph.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "retrain.py", line 363, in create_bottleneck_file
    resized_input_tensor, bottleneck_tensor)
  File "retrain.py", line 331, in run_bottleneck_on_image
    {image_data_tensor: image_data})
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/client/session.py", line 905, in run
    run_metadata_ptr)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/client/session.py", line 1083, in _run
    'Cannot interpret feed_dict key as Tensor: ' + e.args[0])
TypeError: Cannot interpret feed_dict key as Tensor: Tensor Tensor("DecodeJPGInput:0", dtype=string) is not an element of this graph.
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "retrain.py", line 1332, in <module>
    tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/platform/app.py", line 126, in run
    _sys.exit(main(argv))
  File "retrain.py", line 1155, in main
    export_model(module_spec, class_count, FLAGS.saved_model_dir)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/client/session.py", line 1545, in __exit__
    self._default_graph_context_manager.__exit__(exec_type, exec_value, exec_tb)
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/framework/ops.py", line 5086, in get_controller
    yield g
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/framework/ops.py", line 4896, in get_controller
    yield default
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/framework/ops.py", line 5086, in get_controller
    yield g
  File "retrain.py", line 1143, in main
    bottleneck_tensor)
  File "retrain.py", line 847, in run_final_eval
    bottleneck_tensor, FLAGS.tfhub_module))
  File "retrain.py", line 536, in get_random_cached_bottlenecks
    resized_input_tensor, bottleneck_tensor, module_name)
  File "retrain.py", line 411, in get_or_create_bottleneck
    bottleneck_tensor)
  File "retrain.py", line 366, in create_bottleneck_file
    str(e)))
RuntimeError: Error during processing file /workspace/doggo_cattos/cat/cat.333.jpg (Cannot interpret feed_dict key as Tensor: Tensor Tensor("DecodeJPGInput:0", dtyp
e=string) is not an element of this graph.)
```