### PR TITLE
Cast uploaded.keys() to list before indexing in an example

### DIFF
--- a/examples/colab/tf_hub_generative_image_module.ipynb
+++ b/examples/colab/tf_hub_generative_image_module.ipynb
@@ -302,7 +302,7 @@
         "\n",
         "def upload_image():\n",
         "  uploaded = files.upload()\n",
-        "  image = imageio.imread(uploaded[uploaded.keys()[0]])\n",
+        "  image = imageio.imread(uploaded[list(uploaded.keys())[0]])\n",
         "  return transform.resize(image, [128, 128])\n",
         "\n",
         "if image_from_module_space:\n",


### PR DESCRIPTION
In examples/colab/tf_hub_generative_image_module.ipynb
as of python 3 keys() method of dictionary returns a view(DictKeys) object as documented [here](https://docs.python.org/3/library/stdtypes.html#dict.keys) and doesn't support indexing.  Currently python 3 throws `TypeError: 'dict_keys' object does not support indexing`, when ran in colab directly from github([link](https://colab.research.google.com/github/tensorflow/hub/blob/master/examples/colab/tf_hub_generative_image_module.ipynb)) . Casting to list will work both in python 2 and 3.