### PR TITLE
Linkify URL

### DIFF
--- a/docs/modules/google/nnlm-en-dim128/1.md
+++ b/docs/modules/google/nnlm-en-dim128/1.md
@@ -30,7 +30,7 @@ embedding vectors that hash to the same bucket.
 
 #### Sentence embeddings
 Word embeddings are combined into sentence embedding using the `sqrtn` combiner
-(see https://www.tensorflow.org/versions/master/api_docs/python/tf/nn/embedding_lookup_sparse).
+(see [https://www.tensorflow.org/versions/master/api_docs/python/tf/nn/embedding_lookup_sparse](https://www.tensorflow.org/versions/master/api_docs/python/tf/nn/embedding_lookup_sparse)).
 
 #### References
 [1] Yoshua Bengio, Réjean Ducharme, Pascal Vincent, Christian Jauvin.


### PR DESCRIPTION
On GitHub, the URL seems to automatically be linkified, but on the [tensorflow site](https://www.tensorflow.org/hub/modules/google/nnlm-en-dim128/1), the URL does not appear as a link.