### PR TITLE
Remove broken version checking completely. We will assume that TF 1.7…

### DIFF
--- a/tensorflow_hub/__init__.py
+++ b/tensorflow_hub/__init__.py
@@ -18,9 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import re
-import sys
-
 import tensorflow as tf
 
 from tensorflow_hub.estimator import LatestModuleExporter
@@ -36,33 +33,6 @@ from tensorflow_hub.native_module import create_module_spec
 from tensorflow_hub.native_module import load_module_spec
 from tensorflow_hub.version import __version__
 
-
-# TensorFlow Hub depends on features not yet present in a stable TensorFlow
-# release. Until then, we will explicitly check tf.VERSION to make this clear.
-def _check_tensorflow_version(version):
-  # If this is a nightly version, check that it has the last needed bug fixes
-  # from TensorFlow.
-  _NIGHTLY_VERSION = "20180308"  # pylint: disable=invalid_name
-  match = re.search("dev(20[0-9]{6})", version)
-  if match:
-    if match.group(1) >= _NIGHTLY_VERSION:
-      return
-
-  # If this is not a nightly version assume it is a pre-release or stable
-  # version and check only major.minor.
-  _MAIN_VERSION = "1.7"  # pylint: disable=invalid_name
-  match = re.search("^([0-9]+.[0-9]+)", version)
-  if match:
-    if match.group(1) >= _MAIN_VERSION:
-      return
-
-  raise RuntimeError(
-      "TensorFlow Hub depends on 'tf-nightly' build after %s or "
-      "'tensorflow~=%s'. Found tf.VERSION = %s" % (
-          _NIGHTLY_VERSION, _MAIN_VERSION, version))
-
-# Comment/uncomment to skip checking the TensorFlow version.
-_check_tensorflow_version(tf.VERSION)
 
 # Used by doc generation script.
 _allowed_symbols = [


### PR DESCRIPTION
… is already in wide adoption.

PiperOrigin-RevId: 205805576