### PR TITLE
fixing StringIO and BytesIO for Python3

### DIFF
--- a/examples/colab/tf_hub_delf_module.ipynb
+++ b/examples/colab/tf_hub_delf_module.ipynb
@@ -122,7 +122,7 @@
         "from skimage.feature import plot_matches\n",
         "from skimage.measure import ransac\n",
         "from skimage.transform import AffineTransform\n",
-        "from six import StringIO, BytesIO, PY3\n",
+        "from six import BytesIO\n",
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
         "from six.moves.urllib.request import urlopen"
@@ -222,7 +222,7 @@
         "def download_and_resize_image(url, filename, new_width=256, new_height=256):\n",
         "  response = urlopen(url)\n",
         "  image_data = response.read()\n",
-        "  image_data = BytesIO(image_data) if PY3 else StringIO(image_data)\n",
+        "  image_data = BytesIO(image_data)\n",
         "  pil_image = Image.open(image_data)\n",
         "  pil_image = ImageOps.fit(pil_image, (new_width, new_height), Image.ANTIALIAS)\n",
         "  pil_image_rgb = pil_image.convert('RGB')\n",

--- a/examples/colab/tf_hub_delf_module.ipynb
+++ b/examples/colab/tf_hub_delf_module.ipynb
@@ -122,7 +122,7 @@
         "from skimage.feature import plot_matches\n",
         "from skimage.measure import ransac\n",
         "from skimage.transform import AffineTransform\n",
-        "from six import StringIO\n",
+        "from six import StringIO, BytesIO, PY3\n",
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
         "from six.moves.urllib.request import urlopen"
@@ -222,7 +222,8 @@
         "def download_and_resize_image(url, filename, new_width=256, new_height=256):\n",
         "  response = urlopen(url)\n",
         "  image_data = response.read()\n",
-        "  pil_image = Image.open(StringIO(image_data))\n",
+        "  image_data = BytesIO(image_data) if PY3 else StringIO(image_data)\n",
+        "  pil_image = Image.open(image_data)\n",
         "  pil_image = ImageOps.fit(pil_image, (new_width, new_height), Image.ANTIALIAS)\n",
         "  pil_image_rgb = pil_image.convert('RGB')\n",
         "  pil_image_rgb.save(filename, format='JPEG', quality=90)\n",


### PR DESCRIPTION
urlopen returns string in python 2 and bytes in python 3 and so needs to be wrapped with BytesIO for python 3 and StringIO for python 2