### PR TITLE
Hub: Module API description rectified

### DIFF
--- a/docs/api_docs/python/hub/Module.md
+++ b/docs/api_docs/python/hub/Module.md
@@ -281,7 +281,7 @@ Describes the outputs provided by a signature.
 
 #### Returns:
 
-The result of ModuleSpec.get_input_info_dict() for the given signature,
+The result of ModuleSpec.get_output_info_dict() for the given signature,
 and the graph variant selected by `tags` when this Module was initialized.
 
 

--- a/tensorflow_hub/module.py
+++ b/tensorflow_hub/module.py
@@ -275,7 +275,7 @@ class Module(object):
         If None, the default signature is used if defined.
 
     Returns:
-      The result of ModuleSpec.get_input_info_dict() for the given signature,
+      The result of ModuleSpec.get_output_info_dict() for the given signature,
       and the graph variant selected by `tags` when this Module was initialized.
 
     Raises:


### PR DESCRIPTION
Module: get_output_info_dict() description rectified.