### PR TITLE
Minor fix to image retraining example code in retrieving training files

### DIFF
--- a/examples/image_retraining/retrain.py
+++ b/examples/image_retraining/retrain.py
@@ -179,7 +179,7 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
         sub_dir[:-1]
         # tf.gfile.Walk() returns sub-directory with trailing '/' when it is in
         # Google Cloud Storage, which confuses os.path.basename().
-        if sub_dir.startswith('gs://') else sub_dir)
+        if sub_dir.endswith('/') else sub_dir)
 
     if dir_name == image_dir:
       continue

--- a/examples/image_retraining/retrain.py
+++ b/examples/image_retraining/retrain.py
@@ -176,10 +176,9 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
                             for ext in ['JPEG', 'JPG', 'jpeg', 'jpg', 'png']))
     file_list = []
     dir_name = os.path.basename(
-        sub_dir[:-1]
         # tf.gfile.Walk() returns sub-directory with trailing '/' when it is in
         # Google Cloud Storage, which confuses os.path.basename().
-        if sub_dir.endswith('/') else sub_dir)
+        sub_dir[:-1] if sub_dir.endswith('/') else sub_dir)
 
     if dir_name == image_dir:
       continue

--- a/examples/image_retraining/retrain.py
+++ b/examples/image_retraining/retrain.py
@@ -177,8 +177,8 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
     file_list = []
     dir_name = os.path.basename(
         sub_dir[:-1]
-        # GCS returns sub-directory with training '/',
-        # which confuses os.path.basename()
+        # tf.gfile.Walk() returns sub-directory with trailing '/' when it is in
+        # Google Cloud Storage, which confuses os.path.basename().
         if sub_dir.startswith('gs://') else sub_dir)
 
     if dir_name == image_dir:

--- a/examples/image_retraining/retrain.py
+++ b/examples/image_retraining/retrain.py
@@ -175,7 +175,12 @@ def create_image_lists(image_dir, testing_percentage, validation_percentage):
     extensions = sorted(set(os.path.normcase(ext)  # Smash case on Windows.
                             for ext in ['JPEG', 'JPG', 'jpeg', 'jpg', 'png']))
     file_list = []
-    dir_name = os.path.basename(sub_dir)
+    dir_name = os.path.basename(
+        sub_dir[:-1]
+        # GCS returns sub-directory with training '/',
+        # which confuses os.path.basename()
+        if sub_dir.startswith('gs://') else sub_dir)
+
     if dir_name == image_dir:
       continue
     tf.logging.info("Looking for images in '" + dir_name + "'")


### PR DESCRIPTION
tf.gfile.Walk() returns trailing '/' when files are in Google Cloud Storage.