### PR TITLE
Skip KerasLayer test with hparams for TF 2.0.0-alpha0

### DIFF
--- a/tensorflow_hub/keras_layer_test.py
+++ b/tensorflow_hub/keras_layer_test.py
@@ -123,6 +123,8 @@ class KerasLayerTest(tf.test.TestCase):
     self.assertEqual(result, new_result)
 
   def testGetConfigFromConfigWithHParams(self):
+    if tf.__version__ == "2.0.0-alpha0":
+      self.skipTest("b/127938157 broke use of default hparams")
     export_dir = os.path.join(self.get_temp_dir(), "with-hparams")
     _save_model_with_hparams(export_dir)
     layer = hub.KerasLayer(export_dir, arguments=dict(a=10.))  # Leave b=0.


### PR DESCRIPTION
 which has a bug affecting Python defaults for tensor arguments (meanwhile fixed).

PiperOrigin-RevId: 241536440