### PR TITLE
Added Supported Bazel Version in PIP.md

### DIFF
--- a/tensorflow_hub/pip_package/PIP.md
+++ b/tensorflow_hub/pip_package/PIP.md
@@ -14,7 +14,7 @@ limitations under the License.
 =============================================================================-->
 # Creating the TensorFlow Hub pip package using Linux
 
-This requires Python, Bazel and Git. (And TensorFlow for testing the package.)
+This requires Python, Bazel (0.18.1 or Similar) and Git. (And TensorFlow for testing the package.)
 
 ### Activate virtualenv
 


### PR DESCRIPTION
Bazel Build Fails on Higher Version of Bazel ( > 0.18.1 ) due to unsupported symbols like `git_repository`, `new_http_archive` and `http_archive`.
Issue: #274 