### PR TITLE
fix multi-user save error

### DIFF
--- a/examples/image_retraining/retrain.py
+++ b/examples/image_retraining/retrain.py
@@ -136,7 +136,7 @@ FLAGS = None
 MAX_NUM_IMAGES_PER_CLASS = 2 ** 27 - 1  # ~134M
 
 # The location where variable checkpoints will be stored.
-CHECKPOINT_NAME = '/tmp/_retrain_checkpoint'
+CHECKPOINT_NAME = './tmp/_retrain_checkpoint'
 
 # A module is understood as instrumented for quantization with TF-Lite
 # if it contains any of these ops.


### PR DESCRIPTION
When multi-user want to save the checkpoint and _retrain_checkpoint.xxx files, and the files have created by the other users, so it says: 
```
tensorflow.python.framework.errors_impl.PermissionDeniedError: /tmp/checkpoint.tmpxxxx; Operation not permitted.
```
> In the /tmp folder, user can't change the files that other users created .
So it will be better save them in the user's folder.