### PR TITLE
Patch 1

### DIFF
--- a/tensorflow_hub/keras_layer.py
+++ b/tensorflow_hub/keras_layer.py
@@ -90,6 +90,9 @@ class KerasLayer(tf.keras.layers.Layer):
     arguments: optionally, a dict with additional keyword arguments passed
       to the callable. These must be JSON-serializable to save the Keras config
       of this layer.
+    tags: A tag or sequence of tags identifying the MetaGraph to load. Optional
+      if the SavedModel contains a single MetaGraph, as for those exported from
+      `tf.saved_model.load`.
     **kwargs: 'output_shape': A tuple with the (possibly partial) output
       shape of the callable *without* leading batch size. Other arguments
       are pass into the Layer constructor.

--- a/tensorflow_hub/keras_layer.py
+++ b/tensorflow_hub/keras_layer.py
@@ -95,7 +95,7 @@ class KerasLayer(tf.keras.layers.Layer):
       are pass into the Layer constructor.
   """
 
-  def __init__(self, handle, trainable=False, arguments=None, **kwargs):
+  def __init__(self, handle, trainable=False, arguments=None, tags=None, **kwargs):
     # Note: for compatibility with keras-model serialization this layer is
     # json-serializable. If you add or change arguments here, please also update
     # the `get_config` method.
@@ -106,7 +106,7 @@ class KerasLayer(tf.keras.layers.Layer):
     if callable(handle):
       self._func = handle
     else:
-      self._func = module_v2.load(handle)
+      self._func = module_v2.load(handle, tags=tags)
       if not callable(self._func):
         raise ValueError("Non-callable result from hub.load('%s')" %
                          str(handle))

--- a/tensorflow_hub/keras_layer.py
+++ b/tensorflow_hub/keras_layer.py
@@ -103,6 +103,7 @@ class KerasLayer(tf.keras.layers.Layer):
     # json-serializable. If you add or change arguments here, please also update
     # the `get_config` method.
     self._handle = handle
+    self._tags = tags
 
     # Resolve the handle to a callable `func`.
     # NOTE: The name _func gets baked into object-based checkpoints.
@@ -199,6 +200,7 @@ class KerasLayer(tf.keras.layers.Layer):
 
     config.update({
         "handle": self._handle,
+        "tags": self._tags,
     })
 
     if hasattr(self, "_output_shape"):


### PR DESCRIPTION
This is a proposed solution to issue #390 

A `tags` argument is added to `KerasLayer.__init__` which is passed to `module_v2.load` so that a SavedModel with multiple MetaGraphs can identify which MetaGraph to load