### PR TITLE
Added feature and flag to enable tf.experimental.set_memory_growth for GPUs

### DIFF
--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -108,7 +108,7 @@ flags.DEFINE_float(
     "dropout_rate", _DEFAULT_HPARAMS.dropout_rate,
     "The fraction of the input units to drop, used in dropout layer.")
 flags.DEFINE_bool(
-    "set_memory_growth", _DEFAULT_HPARAMS.set_memory_growth,
+    "set_memory_growth", False,
     "If flag is set, memory growth functionality flag will be set as true for "
     "all GPUs prior to training. "
     "More details: https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth"
@@ -160,17 +160,19 @@ def _assert_accuracy(train_result, assert_accuracy_at_least):
     raise AssertionError("ACCURACY FAILED:", accuracy_message)
 
 def _set_gpu_memory_growth():
+  # Original code reference found here: https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
   gpus = tf.config.experimental.list_physical_devices('GPU')
   if gpus:
     try:
       # Currently, memory growth needs to be the same across GPUs
       for gpu in gpus:
         tf.config.experimental.set_memory_growth(gpu, True)
-      logical_gpus = tf.config.experimental.list_logical_devices('GPU')
-      print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
+      print("All GPUs will scale memory steadily")
     except RuntimeError as e:
       # Memory growth must be set before GPUs have been initialized
       print(e)
+  else:
+    print("No GPUs found for set_memory_growth")
 
 def main(args):
   """Main function to be called by absl.app.run() after flag parsing."""
@@ -182,7 +184,7 @@ def main(args):
 
   if FLAGS.set_memory_growth:
     _set_gpu_memory_growth()
-    print("All GPUs will scale memory steadily")
+    
 
   model, labels, train_result = lib.make_image_classifier(
       FLAGS.tfhub_module, image_dir, hparams, FLAGS.image_size)

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -124,8 +124,7 @@ def _get_hparams_from_flags():
       batch_size=FLAGS.batch_size,
       learning_rate=FLAGS.learning_rate,
       momentum=FLAGS.momentum,
-      dropout_rate=FLAGS.dropout_rate,
-      set_memory_growth=FLAGS.set_memory_growth)
+      dropout_rate=FLAGS.dropout_rate)
 
 
 def _check_keras_dependencies():
@@ -163,14 +162,10 @@ def _set_gpu_memory_growth():
   # Original code reference found here: https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
   gpus = tf.config.experimental.list_physical_devices('GPU')
   if gpus:
-    try:
-      # Currently, memory growth needs to be the same across GPUs
-      for gpu in gpus:
-        tf.config.experimental.set_memory_growth(gpu, True)
-      print("All GPUs will scale memory steadily")
-    except RuntimeError as e:
-      # Memory growth must be set before GPUs have been initialized
-      print(e)
+    # Currently, memory growth needs to be the same across GPUs
+    for gpu in gpus:
+      tf.config.experimental.set_memory_growth(gpu, True)
+    print("All GPUs will scale memory steadily")
   else:
     print("No GPUs found for set_memory_growth")
 

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -38,7 +38,7 @@ def get_default_image_dir():
 class HParams(
     collections.namedtuple("HParams", [
         "train_epochs", "do_fine_tuning", "batch_size", "learning_rate",
-        "momentum", "dropout_rate"
+        "momentum", "dropout_rate", "set_memory_growth"
     ])):
   """The hyperparameters for make_image_classifier.
 
@@ -60,7 +60,8 @@ def get_default_hparams():
       batch_size=32,
       learning_rate=0.005,
       momentum=0.9,
-      dropout_rate=0.2)
+      dropout_rate=0.2,
+      set_memory_growth=False)
 
 
 def _get_data_with_keras(image_dir, image_size, batch_size,

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -38,7 +38,7 @@ def get_default_image_dir():
 class HParams(
     collections.namedtuple("HParams", [
         "train_epochs", "do_fine_tuning", "batch_size", "learning_rate",
-        "momentum", "dropout_rate", "set_memory_growth"
+        "momentum", "dropout_rate"
     ])):
   """The hyperparameters for make_image_classifier.
 
@@ -60,8 +60,7 @@ def get_default_hparams():
       batch_size=32,
       learning_rate=0.005,
       momentum=0.9,
-      dropout_rate=0.2,
-      set_memory_growth=False)
+      dropout_rate=0.2)
 
 
 def _get_data_with_keras(image_dir, image_size, batch_size,


### PR DESCRIPTION
In order to resolve GPU memory issues when running the make_image_classifier, I had to enable the experimental memory growth feature in Tensorflow. I noticed that other members of the community had similar issues with TensorFlow in general. 
Example: https://github.com/tensorflow/tensorflow/issues/17048

The implementation for enabling this option for all GPUs seems to be the best option vs implementing a complex flag solution to allow for editing this setting on a per GPU basis.
I implemented a flag to enable this setting for all GPUs per documentation found here: https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth