### PR TITLE
Draw text under top border if object box takes entire image

### DIFF
--- a/examples/colab/object_detection.ipynb
+++ b/examples/colab/object_detection.ipynb
@@ -224,7 +224,7 @@
         "  if top > total_display_str_height:\n",
         "    text_bottom = top\n",
         "  else:\n",
-        "    text_bottom = bottom + total_display_str_height\n",
+        "    text_bottom = top + total_display_str_height\n",
         "  # Reverse list and print from bottom to top.\n",
         "  for display_str in display_str_list[::-1]:\n",
         "    text_width, text_height = font.getsize(display_str)\n",


### PR DESCRIPTION
Sometimes the object box top is at the top of the image.
At the same time, the box bottom can be at the bottom of the image.
In this case, the text is drawn beyond the image.
It this case, it's better to draw text right under the top border.

Before:
![cat1](https://user-images.githubusercontent.com/9107011/76700880-f64fae00-66cc-11ea-8d00-73e2574b8ecd.jpg)
After:
![cat2](https://user-images.githubusercontent.com/9107011/76700881-fbacf880-66cc-11ea-94d1-83ffb0c5b5e0.jpg)

