### PR TITLE
Update tf2_saved_model.md

### DIFF
--- a/docs/tf2_saved_model.md
+++ b/docs/tf2_saved_model.md
@@ -281,7 +281,7 @@ If the model use dropout, batch normalization, or similar training techniques
 that involve hyperparameters, set them to values that make sense across many
 expected target problems and batch sizes. (As of this writing, saving from
 Keras does not make it easy to let consumers adjust them, but see
-[tensorflow/examples/saved_model/integration_tests/export_mnist.py](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/examples/saved_model/integration_tests/export_mnist.py)
+[tensorflow/examples/saved_model/integration_tests/export_mnist_cnn.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/saved_model/integration_tests/export_mnist_cnn.py)
 for some crude workarounds.)
 
 Weight regularizers on individual layers are saved (with their regularization


### PR DESCRIPTION
URL fixed for export_mnist_cnn.py
The docs has a incorrect url, here is the correct one
