### PR TITLE
Pip install for TF2 needs updating

### DIFF
--- a/examples/colab/tf2_arbitrary_image_stylization.ipynb
+++ b/examples/colab/tf2_arbitrary_image_stylization.ipynb
@@ -90,7 +90,7 @@
       },
       "source": [
         "# We want to use TensorFlow 2.0 in the Eager mode for this demonstration. But this module works as well with the Graph mode.\n",
-        "!pip install -U --pre tensorflow-gpu --quiet"
+        "!pip install tensorflow --quiet"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
TF2 installs GPU by default - need to drop the -gpu modifier to install correctly via pip in colab.

likely the same issue in all TF2 colab examples