### PR TITLE
Optionally write TensorBoard summary logs

### DIFF
--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -188,7 +188,7 @@ def main(args):
     _set_gpu_memory_growth()
 
   model, labels, train_result = lib.make_image_classifier(
-      FLAGS.tfhub_module, image_dir, hparams, FLAGS.summaries_dir, FLAGS.image_size)
+      FLAGS.tfhub_module, image_dir, hparams, FLAGS.image_size, FLAGS.summaries_dir)
   if FLAGS.assert_accuracy_at_least:
     _assert_accuracy(train_result, FLAGS.assert_accuracy_at_least)
   print("Done with training.")

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -80,6 +80,9 @@ flags.DEFINE_string(
     "Where to save the labels (that is, names of image subdirectories). "
     "The lines in this file appear in the same order as the predictions "
     "of the model.")
+flags.DEFINE_string(
+    "summaries_dir", None,
+    "Where to save summary logs for TensorBoard.")
 flags.DEFINE_float(
     "assert_accuracy_at_least", None,
     "If set, the program fails if the validation accuracy at the end of "
@@ -185,7 +188,7 @@ def main(args):
     _set_gpu_memory_growth()
 
   model, labels, train_result = lib.make_image_classifier(
-      FLAGS.tfhub_module, image_dir, hparams, FLAGS.image_size)
+      FLAGS.tfhub_module, image_dir, hparams, FLAGS.summaries_dir, FLAGS.image_size)
   if FLAGS.assert_accuracy_at_least:
     _assert_accuracy(train_result, FLAGS.assert_accuracy_at_least)
   print("Done with training.")

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -191,7 +191,7 @@ def build_model(module_layer, hparams, image_size, num_classes):
   return model
 
 
-def train_model(model, hparams, train_data_and_size, valid_data_and_size):
+def train_model(model, hparams, train_data_and_size, valid_data_and_size, log_dir):
   """Trains model with the given data and hyperparameters.
 
   Args:
@@ -209,6 +209,7 @@ def train_model(model, hparams, train_data_and_size, valid_data_and_size):
     valid_data_and_size: A (data, size) tuple in which data is validation data
       to be fed in tf.keras.Model.fit(), size is a Python integer with the
       numbers of validation.
+    log_dir: A directory to write logs for TensorBoard into.
 
   Returns:
     The tf.keras.callbacks.History object returned by tf.keras.Model.fit().
@@ -224,15 +225,19 @@ def train_model(model, hparams, train_data_and_size, valid_data_and_size):
       metrics=["accuracy"])
   steps_per_epoch = train_size // hparams.batch_size
   validation_steps = valid_size // hparams.batch_size
+  callbacks = []
+  if log_dir != None:
+    callbacks.append(tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1))
   return model.fit(
       train_data,
       epochs=hparams.train_epochs,
       steps_per_epoch=steps_per_epoch,
       validation_data=valid_data,
-      validation_steps=validation_steps)
+      validation_steps=validation_steps,
+      callbacks=callbacks)
 
 
-def make_image_classifier(tfhub_module, image_dir, hparams,
+def make_image_classifier(tfhub_module, image_dir, hparams, log_dir=None,
                           requested_image_size=None):
   """Builds and trains a TensorFLow model for image classification.
 
@@ -256,5 +261,5 @@ def make_image_classifier(tfhub_module, image_dir, hparams,
 
   model = build_model(module_layer, hparams, image_size, len(labels))
   train_result = train_model(model, hparams, train_data_and_size,
-                             valid_data_and_size)
+                             valid_data_and_size, log_dir)
   return model, labels, train_result

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -191,7 +191,7 @@ def build_model(module_layer, hparams, image_size, num_classes):
   return model
 
 
-def train_model(model, hparams, train_data_and_size, valid_data_and_size, log_dir):
+def train_model(model, hparams, train_data_and_size, valid_data_and_size, log_dir=None):
   """Trains model with the given data and hyperparameters.
 
   Args:
@@ -209,7 +209,8 @@ def train_model(model, hparams, train_data_and_size, valid_data_and_size, log_di
     valid_data_and_size: A (data, size) tuple in which data is validation data
       to be fed in tf.keras.Model.fit(), size is a Python integer with the
       numbers of validation.
-    log_dir: A directory to write logs for TensorBoard into.
+    log_dir: A directory to write logs for TensorBoard into (defaults to None,
+      no logs will then be written).
 
   Returns:
     The tf.keras.callbacks.History object returned by tf.keras.Model.fit().
@@ -237,8 +238,9 @@ def train_model(model, hparams, train_data_and_size, valid_data_and_size, log_di
       callbacks=callbacks)
 
 
-def make_image_classifier(tfhub_module, image_dir, hparams, log_dir=None,
-                          requested_image_size=None):
+def make_image_classifier(tfhub_module, image_dir, hparams,
+                          requested_image_size=None,
+                          log_dir=None):
   """Builds and trains a TensorFLow model for image classification.
 
   Args:
@@ -249,6 +251,8 @@ def make_image_classifier(tfhub_module, image_dir, hparams, log_dir=None,
     requested_image_size: A Python integer controlling the size of images to
       feed into the Hub module. If the module has a fixed input size, this
       must be omitted or set to that same value.
+    log_dir: A directory to write logs for TensorBoard into (defaults to None,
+      no logs will then be written).
   """
   module_layer = hub.KerasLayer(tfhub_module,
                                 trainable=hparams.do_fine_tuning)


### PR DESCRIPTION
With the new --summaries_dir argument a callback to model.fit() is added to write logs which can be used with TensorBoard.

This PR solves #541 and adds a feature which is missing in comparison with the old `image_retraining/retrain.py` tool.