### PR TITLE
Check model files when cached model folder exists

### DIFF
--- a/tensorflow_hub/resolver.py
+++ b/tensorflow_hub/resolver.py
@@ -380,12 +380,12 @@ def atomic_download(handle,
                                              overwrite=False)
         # Must test condition again, since another process could have created
         # the module and deleted the old lock file since last test.
-        if tf_v1.gfile.Exists(module_dir) and (
-          tf_v1.gfile.Exists(os.path.join(module_dir, "saved_model.pbtxt")) or
-          tf_v1.gfile.Exists(os.path.join(module_dir, "saved_model.pb"))
-        ):
+        if tf_v1.gfile.Exists(module_dir) and \
+          tf_v1.gfile.ListDirectory(module_dir):
           # Lock file will be deleted in the finally-clause.
           return module_dir
+        if tf_v1.gfile.Exists(module_dir):
+          tf_v1.gfile.DeleteRecursively(module_dir)
         break  # Proceed to downloading the module.
       # These errors are believed to be permanent problems with the
       # module_dir that justify failing the download.

--- a/tensorflow_hub/resolver.py
+++ b/tensorflow_hub/resolver.py
@@ -380,8 +380,8 @@ def atomic_download(handle,
                                              overwrite=False)
         # Must test condition again, since another process could have created
         # the module and deleted the old lock file since last test.
-        if tf_v1.gfile.Exists(module_dir) and \
-          tf_v1.gfile.ListDirectory(module_dir):
+        if (tf_v1.gfile.Exists(module_dir) and 
+            tf_v1.gfile.ListDirectory(module_dir)):
           # Lock file will be deleted in the finally-clause.
           return module_dir
         if tf_v1.gfile.Exists(module_dir):

--- a/tensorflow_hub/resolver.py
+++ b/tensorflow_hub/resolver.py
@@ -380,7 +380,10 @@ def atomic_download(handle,
                                              overwrite=False)
         # Must test condition again, since another process could have created
         # the module and deleted the old lock file since last test.
-        if tf_v1.gfile.Exists(module_dir):
+        if tf_v1.gfile.Exists(module_dir) and (
+          tf_v1.gfile.Exists(os.path.join(module_dir, "saved_model.pbtxt")) or
+          tf_v1.gfile.Exists(os.path.join(module_dir, "saved_model.pb"))
+        ):
           # Lock file will be deleted in the finally-clause.
           return module_dir
         break  # Proceed to downloading the module.

--- a/tensorflow_hub/resolver_test.py
+++ b/tensorflow_hub/resolver_test.py
@@ -261,9 +261,8 @@ class ResolverTest(tf.test.TestCase):
       tf_utils.atomic_write_string_to_file(
           os.path.join(module_dir, "file"), "content", False)
 
-    # Delete existing folder and create an empty one.
-    if tf_v1.gfile.Exists(module_dir):
-      tf_v1.gfile.DeleteRecursively(module_dir)
+    # Create an empty folder before downloading.
+    self.assertFalse(tf_v1.gfile.Exists(module_dir))
     tf_v1.gfile.MakeDirs(module_dir)
 
     self.assertEqual(


### PR DESCRIPTION
When loading a module with a TF-Hub link. The resolver only checks if the model folder exists but not checks if the model files exist inside the folder. The situation happens quite possible, since usually the module is cached in /tmp. So it's likely that the system only delete model files but keep the model folder, which causes errors like in #575.