### PR TITLE
Update image_retraining colab

### DIFF
--- a/examples/colab/tf2_image_retraining.ipynb
+++ b/examples/colab/tf2_image_retraining.ipynb
@@ -1,22 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "TF Hub for TF2: Retraining an image classifier",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [
-        "ScitaPqhKtuW"
-      ],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -345,8 +327,8 @@
         "AUTOTUNE = tf.data.experimental.AUTOTUNE\n",
         "\n",
         "image_dir = pathlib.Path(image_dir)\n",
-        "class_names = np.array([item.name for item in image_dir.glob('*') \n",
-        "                        if item.name != 'LICENSE.txt'])\n",
+        "class_names = tuple(item.name for item in image_dir.glob('*') \n",
+        "                    if item.is_dir())\n",
         "image_count = len(list(image_dir.glob('*/*')))\n",
         "# 8 * batch_size is a good choice for shuffle buffer size.\n",
         "buffer_size = BATCH_SIZE * 8\n",
@@ -630,5 +612,23 @@
       "execution_count": 0,
       "outputs": []
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "TF Hub for TF2: Retraining an image classifier",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "ScitaPqhKtuW"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/colab/tf2_image_retraining.ipynb
+++ b/examples/colab/tf2_image_retraining.ipynb
@@ -1,4 +1,22 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "TF Hub for TF2: Retraining an image classifier",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "ScitaPqhKtuW"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -14,13 +32,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "jvztxQ6VsK2k"
+        "id": "jvztxQ6VsK2k",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Copyright 2019 The TensorFlow Hub Authors. All Rights Reserved.\n",
         "#\n",
@@ -36,7 +52,9 @@
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License.\n",
         "# =============================================================================="
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -45,7 +63,7 @@
         "id": "oYM61xrTsP5d"
       },
       "source": [
-        "# Retraining an Image Classifier\n"
+        "# TF Hub for TF2: Retraining an image classifier\n"
       ]
     },
     {
@@ -55,20 +73,20 @@
         "id": "MfBg1C5NB3X0"
       },
       "source": [
-        "\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://www.tensorflow.org/hub/tutorials/tf2_image_retraining\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/hub/blob/master/examples/colab/tf2_image_retraining.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" /\u003eRun in Google Colab\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca target=\"_blank\" href=\"https://github.com/tensorflow/hub/blob/master/examples/colab/tf2_image_retraining.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" /\u003eView source on GitHub\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "  \u003ctd\u003e\n",
-        "    \u003ca href=\"https://storage.googleapis.com/tensorflow_docs/hub/examples/colab/tf2_image_retraining.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\n",
-        "  \u003c/td\u003e\n",
-        "\u003c/table\u003e"
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/hub/tutorials/tf2_image_retraining\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/hub/blob/master/examples/colab/tf2_image_retraining.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/hub/blob/master/examples/colab/tf2_image_retraining.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/hub/examples/colab/tf2_image_retraining.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -102,16 +120,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "dlauq-4FWGZM"
+        "id": "dlauq-4FWGZM",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import itertools\n",
         "import os\n",
+        "import pathlib\n",
+        "import functools\n",
         "\n",
         "import matplotlib.pylab as plt\n",
         "import numpy as np\n",
@@ -122,7 +140,9 @@
         "print(\"TF version:\", tf.__version__)\n",
         "print(\"Hub version:\", hub.__version__)\n",
         "print(\"GPU is\", \"available\" if tf.test.is_gpu_available() else \"NOT AVAILABLE\")"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -138,13 +158,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "FlsEcKVeuCnf"
+        "id": "FlsEcKVeuCnf",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "module_selection = (\"mobilenet_v2_100_224\", 224) #@param [\"(\\\"mobilenet_v2_100_224\\\", 224)\", \"(\\\"inception_v3\\\", 299)\"] {type:\"raw\", allow-input: true}\n",
         "handle_base, pixels = module_selection\n",
@@ -153,7 +171,9 @@
         "print(\"Using {} with input size {}\".format(MODULE_HANDLE, IMAGE_SIZE))\n",
         "\n",
         "BATCH_SIZE = 32 #@param {type:\"integer\"}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -169,52 +189,193 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "WBtFK1hO8KsO"
+        "id": "WBtFK1hO8KsO",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "data_dir = tf.keras.utils.get_file(\n",
+        "image_dir = tf.keras.utils.get_file(\n",
         "    'flower_photos',\n",
         "    'https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz',\n",
         "    untar=True)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1rNoNBE9Ns3n",
+        "colab_type": "text"
+      },
+      "source": [
+        "We first define some preprocessing functions that map an image path to a (image, label) pair, by reading the image file and obtaining its label from its path."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "rrjRuFm_Mjv3",
         "colab_type": "code",
-        "id": "umB5tswsfTEQ"
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "datagen_kwargs = dict(rescale=1./255, validation_split=.20)\n",
-        "dataflow_kwargs = dict(target_size=IMAGE_SIZE, batch_size=BATCH_SIZE,\n",
-        "                   interpolation=\"bilinear\")\n",
+        "def _get_label(file_path, class_names):\n",
+        "  # convert the path to a list of path components\n",
+        "  parts = tf.strings.split(file_path, os.path.sep)\n",
+        "  # The second to last is the class-directory\n",
+        "  return parts[-2] == class_names\n",
         "\n",
-        "valid_datagen = tf.keras.preprocessing.image.ImageDataGenerator(\n",
-        "    **datagen_kwargs)\n",
-        "valid_generator = valid_datagen.flow_from_directory(\n",
-        "    data_dir, subset=\"validation\", shuffle=False, **dataflow_kwargs)\n",
+        "\n",
+        "def _decode_img(img, image_size):\n",
+        "  # convert the compressed string to a 3D uint8 tensor\n",
+        "  img = tf.image.decode_jpeg(img, channels=3)\n",
+        "  # Use `convert_image_dtype` to convert to floats in the [0,1] range.\n",
+        "  # Rescale is no longer needed, as this conversion will automatically\n",
+        "  # scale to [0, 1] when dtype is float.\n",
+        "  img = tf.image.convert_image_dtype(img, tf.float32)\n",
+        "  return tf.image.resize(img, image_size)\n",
+        "\n",
+        "\n",
+        "def _process_path(file_path, image_size, class_names):\n",
+        "  label = _get_label(file_path, class_names)\n",
+        "  # load the raw data from the file as a string\n",
+        "  img = tf.io.read_file(file_path)\n",
+        "  img = _decode_img(img, image_size)\n",
+        "  return img, label"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Rv-xLeGeOlS5",
+        "colab_type": "text"
+      },
+      "source": [
+        "Next, we define helper functions for data augmentation. We implement these augmentation methods based on `tf.image` ops."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "umB5tswsfTEQ",
+        "colab": {}
+      },
+      "source": [
+        "# This module defines helper functions that convert rotation and zoom operations\n",
+        "# into image transformations.\n",
+        "from tensorflow.python.keras.layers.preprocessing import image_preprocessing as img_pre\n",
         "\n",
         "do_data_augmentation = False #@param {type:\"boolean\"}\n",
-        "if do_data_augmentation:\n",
-        "  train_datagen = tf.keras.preprocessing.image.ImageDataGenerator(\n",
-        "      rotation_range=40,\n",
-        "      horizontal_flip=True,\n",
-        "      width_shift_range=0.2, height_shift_range=0.2,\n",
-        "      shear_range=0.2, zoom_range=0.2,\n",
-        "      **datagen_kwargs)\n",
-        "else:\n",
-        "  train_datagen = valid_datagen\n",
-        "train_generator = train_datagen.flow_from_directory(\n",
-        "    data_dir, subset=\"training\", shuffle=True, **dataflow_kwargs)"
+        "\n",
+        "def rotate(inputs, lower=-10, upper=10):\n",
+        "  inputs_shape = tf.shape(inputs)\n",
+        "  batch_size = inputs_shape[0]\n",
+        "  h_axis, w_axis = 1, 2\n",
+        "  img_hd = tf.cast(inputs_shape[h_axis], tf.float32)\n",
+        "  img_wd = tf.cast(inputs_shape[w_axis], tf.float32)\n",
+        "  min_angle = lower / 360.0 * 2 * np.pi\n",
+        "  max_angle = upper / 360.0 * 2 * np.pi\n",
+        "  angles = tf.random.uniform(\n",
+        "      shape=[batch_size], \n",
+        "      minval=min_angle, \n",
+        "      maxval=max_angle)\n",
+        "  return img_prep.transform(\n",
+        "      inputs,\n",
+        "      img_prep.get_rotation_matrix(angles, img_hd, img_wd),\n",
+        "      interpolation='bilinear')\n",
+        "\n",
+        "\n",
+        "def zoom(inputs, h_lower=-0.2, h_upper=0.2):\n",
+        "  inputs_shape = tf.shape(inputs)\n",
+        "  batch_size = inputs_shape[0]\n",
+        "  h_axis, w_axis = 1, 2\n",
+        "  img_hd = tf.cast(inputs_shape[h_axis], tf.float32)\n",
+        "  img_wd = tf.cast(inputs_shape[w_axis], tf.float32)\n",
+        "  height_zoom = tf.random.uniform(\n",
+        "      shape=[batch_size, 1], \n",
+        "      minval=1. + h_lower, \n",
+        "      maxval=1. + h_upper)\n",
+        "  width_zoom = height_zoom\n",
+        "  zooms = tf.cast(\n",
+        "      tf.concat([width_zoom, height_zoom], axis=1), \n",
+        "      dtype=inputs.dtype)\n",
+        "  return img_prep.transform(\n",
+        "      inputs, img_prep.get_zoom_matrix(zooms, img_hd, img_wd),\n",
+        "      interpolation='bilinear')\n",
+        "\n",
+        "\n",
+        "def image_augmentation(img, labels, augment_params):\n",
+        "  img = tf.image.random_flip_left_right(img)\n",
+        "  upper = 10\n",
+        "  img = rotate(img, -upper, upper)\n",
+        "  upper = 0.1\n",
+        "  img = zoom(img, -upper, upper)\n",
+        "  return img, labels"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "S0JGjhNmQH1l",
+        "colab_type": "text"
+      },
+      "source": [
+        "Now we can define the complete data loading pipeline."
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9bHqKWh9QNRX",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# The ratio of validation set.\n",
+        "validation_split = 0.2  #@param {type:\"slider\", min:0, max:1, step:0.1}\n",
+        "# Only cache a dataset if it fits into the memory.\n",
+        "cache = True  #@param {type:\"boolean\"}\n",
+        "AUTOTUNE = tf.data.experimental.AUTOTUNE\n",
+        "\n",
+        "image_dir = pathlib.Path(image_dir)\n",
+        "class_names = np.array([item.name for item in image_dir.glob('*') \n",
+        "                        if item.name != 'LICENSE.txt'])\n",
+        "image_count = len(list(image_dir.glob('*/*')))\n",
+        "# 8 * batch_size is a good choice for shuffle buffer size.\n",
+        "buffer_size = BATCH_SIZE * 8\n",
+        "# shuffle here to avoid val dataset containing a single type of examples.\n",
+        "list_ds = tf.data.Dataset.list_files(str(image_dir/'*/*'), shuffle=True)\n",
+        "labeled_ds = list_ds.map(\n",
+        "    functools.partial(\n",
+        "        _process_path, image_size=IMAGE_SIZE, class_names=class_names), \n",
+        "    num_parallel_calls=AUTOTUNE)\n",
+        "valid_size = int(image_count * validation_split)\n",
+        "train_size = image_count - valid_size\n",
+        "valid_ds = labeled_ds.take(valid_size)\n",
+        "train_ds = labeled_ds.skip(valid_size)\n",
+        "if cache:\n",
+        "  valid_ds = valid_ds.cache()\n",
+        "  train_ds = train_ds.cache()\n",
+        "\n",
+        "valid_ds = valid_ds.batch(BATCH_SIZE).prefetch(buffer_size=AUTOTUNE)\n",
+        "train_ds = train_ds.shuffle(buffer_size=buffer_size).repeat()\\\n",
+        "    .batch(BATCH_SIZE).prefetch(buffer_size=AUTOTUNE)\n",
+        "\n",
+        "if do_data_augmentation:\n",
+        "  train_ds = train_ds.map(\n",
+        "    functools.partial(\n",
+        "        image_augmentation, augment_params=augment_params),\n",
+        "    num_parallel_calls=AUTOTUNE)"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -232,26 +393,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "RaJW3XrPyFiF"
+        "id": "RaJW3XrPyFiF",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "do_fine_tuning = False #@param {type:\"boolean\"}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "50FYNIb1dmJH"
+        "id": "50FYNIb1dmJH",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "print(\"Building model with\", MODULE_HANDLE)\n",
         "model = tf.keras.Sequential([\n",
@@ -260,12 +419,14 @@
         "    tf.keras.layers.InputLayer(input_shape=IMAGE_SIZE + (3,)),\n",
         "    hub.KerasLayer(MODULE_HANDLE, trainable=do_fine_tuning),\n",
         "    tf.keras.layers.Dropout(rate=0.2),\n",
-        "    tf.keras.layers.Dense(train_generator.num_classes,\n",
+        "    tf.keras.layers.Dense(len(class_names),\n",
         "                          kernel_regularizer=tf.keras.regularizers.l2(0.0001))\n",
         "])\n",
         "model.build((None,)+IMAGE_SIZE+(3,))\n",
         "model.summary()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -279,48 +440,46 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "9f3yBUvkd_VJ"
+        "id": "9f3yBUvkd_VJ",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model.compile(\n",
         "  optimizer=tf.keras.optimizers.SGD(lr=0.005, momentum=0.9), \n",
         "  loss=tf.keras.losses.CategoricalCrossentropy(from_logits=True, label_smoothing=0.1),\n",
         "  metrics=['accuracy'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "w_YKX2Qnfg6x"
+        "id": "w_YKX2Qnfg6x",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "steps_per_epoch = train_generator.samples // train_generator.batch_size\n",
-        "validation_steps = valid_generator.samples // valid_generator.batch_size\n",
+        "steps_per_epoch = train_size // BATCH_SIZE\n",
+        "validation_steps = valid_size // BATCH_SIZE\n",
         "hist = model.fit(\n",
-        "    train_generator,\n",
-        "    epochs=5, steps_per_epoch=steps_per_epoch,\n",
-        "    validation_data=valid_generator,\n",
+        "    train_ds,\n",
+        "    epochs=20, steps_per_epoch=steps_per_epoch,\n",
+        "    validation_data=valid_ds,\n",
         "    validation_steps=validation_steps).history"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "CYOw0fTO1W4x"
+        "id": "CYOw0fTO1W4x",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "plt.figure()\n",
         "plt.ylabel(\"Loss (training and validation)\")\n",
@@ -335,7 +494,9 @@
         "plt.ylim([0,1])\n",
         "plt.plot(hist[\"accuracy\"])\n",
         "plt.plot(hist[\"val_accuracy\"])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -349,17 +510,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "LGvTi69oIc2d"
+        "id": "LGvTi69oIc2d",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "saved_model_path = \"/tmp/saved_flowers_model\"\n",
         "tf.saved_model.save(model, saved_model_path)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -379,13 +540,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Va1Vo92fSyV6"
+        "id": "Va1Vo92fSyV6",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Optimization settings\n",
         "# docs_infra: no_execute\n",
@@ -398,7 +557,7 @@
         "  # Use a bounded number of training examples without labels for calibration.\n",
         "  # TFLiteConverter expects a list of input tensors, each with batch size 1.\n",
         "  representative_dataset = lambda: itertools.islice(\n",
-        "      ([image[None, ...]] for batch, _ in train_generator for image in batch),\n",
+        "      ([image[None, ...]] for batch, _ in train_ds for image in batch),\n",
         "      num_calibration_examples)\n",
         "\n",
         "converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_path)\n",
@@ -412,17 +571,17 @@
         "  f.write(lite_model_content)\n",
         "print(\"Wrote %sTFLite model of %d bytes.\" %\n",
         "      (\"optimized \" if optimize_lite_model else \"\", len(lite_model_content)))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "_wqEmD0xIqeG"
+        "id": "_wqEmD0xIqeG",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# docs_infra: no_execute\n",
         "interpreter = tf.lite.Interpreter(model_content=lite_model_content)\n",
@@ -432,23 +591,23 @@
         "  interpreter.set_tensor(interpreter.get_input_details()[0]['index'], images)\n",
         "  interpreter.invoke()\n",
         "  return interpreter.get_tensor(interpreter.get_output_details()[0]['index'])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "JMMK-fZrKrk8"
+        "id": "JMMK-fZrKrk8",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@markdown For rapid experimentation, start with a moderate number of examples.\n",
         "# docs_infra: no_execute\n",
         "num_eval_examples = 50  #@param {type:\"slider\", min:0, max:700}\n",
         "eval_dataset = ((image, label)  # TFLite expects batch size 1.\n",
-        "                for batch in train_generator\n",
+        "                for batch in train_ds\n",
         "                for (image, label) in zip(*batch))\n",
         "count = 0\n",
         "count_lite_tf_agree = 0\n",
@@ -462,30 +621,14 @@
         "  count +=1\n",
         "  if y_lite == y_tf: count_lite_tf_agree += 1\n",
         "  if y_lite == y_true: count_lite_correct += 1\n",
-        "  if count \u003e= num_eval_examples: break\n",
+        "  if count >= num_eval_examples: break\n",
         "print(\"TF Lite model agrees with original model on %d of %d examples (%g%%).\" %\n",
         "      (count_lite_tf_agree, count, 100.0 * count_lite_tf_agree / count))\n",
         "print(\"TF Lite model is accurate on %d of %d examples (%g%%).\" %\n",
         "      (count_lite_correct, count, 100.0 * count_lite_correct / count))"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [
-        "ScitaPqhKtuW"
       ],
-      "name": "TF Hub for TF2: Retraining an image classifier",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
+      "execution_count": 0,
+      "outputs": []
     }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }


### PR DESCRIPTION
This PR updates the image_retraining colab by replacing `ImageDataGenerator` with `tf.data.Dataset` pipeline and `tf.image`-based augmentation.

I will submit another PR that updates the `make_image_classifier` tool by also adding multi-GPU training.