### PR TITLE
Adding deeplabv3-mobilenetv2

### DIFF
--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-ade20k/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-ade20k/1.md
@@ -1,0 +1,24 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2-ade20k/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/deeplabv3_mnv2_ade20k_train_2018_12_03_tflite.tar.gz -->
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
+<!-- dataset: ADE20k -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`mobilenetv2_ade20k_train`](http://download.tensorflow.org/models/deeplabv3_mnv2_ade20k_train_2018_12_03.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_ADE20k.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-xception65/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-xception65/1.md
@@ -1,0 +1,24 @@
+# Lite sayakpaul/deeplabv3-xception65-ade20k/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/deeplabv3_xception_ade20k_train_tflite.tar.gz -->
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (xception65_ade20k_train) -->
+<!-- dataset: ADE20k -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`xception65_ade20k_train`](http://download.tensorflow.org/models/deeplabv3_xception_ade20k_train_2018_05_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_ADE20k.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -14,7 +14,7 @@ DeepLab is a state-of-art deep learning model for semantic image segmentation, w
 
 ### Note
 - The TensorFlow Lite model was converted from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLab_TFLite_COCO.ipynb). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 
 
 ### Acknowledgements
 Thanks to Khanh LeViet for his constant guidance. 

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -1,4 +1,4 @@
-# Module sayakpaul/deeplabv3-mobilenetv2/1
+# Lite sayakpaul/deeplabv3-mobilenetv2/1
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/mobilenetv2_coco_voctrainval_tflite.tar.gz -->
@@ -7,7 +7,6 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->
-<!-- format: tflite -->
 <!-- license: Apache-2.0 -->
 
 ### Overview

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -5,7 +5,7 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- module-type: image-segmentation -->
 <!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
 <!-- dataset: PASCAL VOC 2012 -->
-<!-- fine-tunable: false
+<!-- fine-tunable: false -->
 <!-- language: en -->
 <!-- format: tflite -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -5,6 +5,7 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- module-type: image-segmentation -->
 <!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
 <!-- dataset: PASCAL VOC 2012 -->
+<!-- fine-tunable: false
 <!-- language: en -->
 <!-- format: tflite -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -1,0 +1,24 @@
+# Module sayakpaul/deeplabv3-mobilenetv2/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/mobilenetv2_coco_voctrainval_tflite.tar.gz -->
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- dataset: PASCAL VOC 2012 -->
+<!-- language: en -->
+<!-- format: tflite -->
+<!-- license: Apache-2.0 -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLab_TFLite_COCO.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv3-cityscapes/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv3-cityscapes/1.md
@@ -1,0 +1,24 @@
+# Lite sayakpaul/deeplabv3-mobilenetv3-cityscapes/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/mobilenetv3_large_cityscapes_trainfine_tflite.tar.gz -->
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv3_large_cityscapes_trainfine) -->
+<!-- dataset: CityScapes -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`mobilenetv3_large_cityscapes_trainfine`](http://download.tensorflow.org/models/deeplab_mnv3_large_cityscapes_trainfine_2019_11_15.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_CityScapes.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-xception65-cityscapes/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-xception65-cityscapes/1.md
@@ -1,0 +1,24 @@
+# Lite sayakpaul/deeplabv3-xception65-cityscapes/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/xception65_cityscapes_trainfine_tflite.tar.gz -->
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (xception65_cityscapes_trainfine) -->
+<!-- dataset: CityScapes -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`xception65_cityscapes_trainfine`](http://download.tensorflow.org/models/deeplabv3_cityscapes_train_2018_02_06.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_CityScapes.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-xception65/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-xception65/1.md
@@ -1,0 +1,24 @@
+# Lite sayakpaul/deeplabv3-xception65/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/xception_coco_voctrainval_tflite.tar.gz -->
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (xception65_coco_voc_trainaug) -->
+<!-- dataset: PASCAL VOC 2012 -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`xception65_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_pascal_train_aug_2018_01_04.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/sayakpaul.md
+++ b/tfhub_dev/assets/sayakpaul/sayakpaul.md
@@ -1,5 +1,5 @@
 # Publisher sayakpaul
-Sayak Paul (@RisingSayak).
+Sayak Paul.
 
 [![Icon URL]](https://avatars2.githubusercontent.com/u/22957388?s=400&u=8e6ab48fac4dbd07307b0f7617a1a7a3acdb573a&v=4)
 
@@ -9,4 +9,5 @@ Deep Learning Associate at PyImageSearch.
 Google Developers Expert in Machine Learning.
 
 **GitHub:** [sayakpaul](https://github.com/sayakpaul)\
-**Personal Website:** [sayak.dev](https://sayak.dev)
+**Personal Website:** [sayak.dev](https://sayak.dev)\
+**Twitter:** [@RisingSayak](https://twitter.com/RisingSayak)

--- a/tfhub_dev/assets/sayakpaul/sayakpaul.md
+++ b/tfhub_dev/assets/sayakpaul/sayakpaul.md
@@ -1,0 +1,12 @@
+# Publisher sayakpaul
+Sayak Paul (@RisingSayak).
+
+[![Icon URL]](https://avatars2.githubusercontent.com/u/22957388?s=400&u=8e6ab48fac4dbd07307b0f7617a1a7a3acdb573a&v=4)
+
+## Details
+Sayak Paul ([@RisingSayak](https://twitter.com/RisingSayak)).
+Deep Learning Associate at PyImageSearch.
+Google Developers Expert in Machine Learning.
+
+**GitHub:** [sayakpaul](https://github.com/sayakpaul)\
+**Personal Website:** [sayak.dev](https://sayak.dev)


### PR DESCRIPTION
Hi. 

Currently, the TFLite variant of the DeepLabV3 model that is available on TFHub is probably coming from this checkpoint- `mobilenetv2_dm05_coco_voc_trainval`. The TFLite model proposed in this PR is a different one and enhances performance without any unnecessary size increase or drop in segmentation quality. 