### PR TITLE
Update data pipeline and distribute strategy for make_image_classifier

### DIFF
--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -130,7 +130,7 @@ flags.DEFINE_float(
 )
 flags.DEFINE_bool(
     "cache", _DEFAULT_HPARAMS.cache,
-    "Cache datasets to speed up data loading. Set to true only if"
+    "Cache datasets to speed up data loading. Set to true only if "
     "your dataset is able to be loaded to the memory completely."
 )
 flags.DEFINE_float(
@@ -139,12 +139,17 @@ flags.DEFINE_float(
 )
 flags.DEFINE_bool(
     "do_data_augmentation", _DEFAULT_HPARAMS.do_data_augmentation,
-    "Whether do data augmentation on training set."
-    "Can use default augmentation params or specifying them.")
-flags.DEFINE_integer("rotation_range", _DEFAULT_HPARAMS.rotation_range,
-                     "Degree range for random rotation.")
-flags.DEFINE_bool("horizontal_flip", _DEFAULT_HPARAMS.horizontal_flip,
-                  "Horizontally flip images.")
+    "Whether do data augmentation on training set. "
+    "Can use default augmentation params or specifying them."
+)
+flags.DEFINE_integer(
+    "rotation_range", _DEFAULT_HPARAMS.rotation_range,
+    "Degree range for random rotation."
+)
+flags.DEFINE_bool(
+    "horizontal_flip", _DEFAULT_HPARAMS.horizontal_flip,
+    "Horizontally flip images."
+)
 flags.DEFINE_float(
     "width_shift_range", _DEFAULT_HPARAMS.width_shift_range,
     "Shift images horizontally by pixels(if >=1) or by ratio(if <1).")

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -115,61 +115,49 @@ flags.DEFINE_bool(
     "If flag is set, memory growth functionality flag will be set as true for "
     "all GPUs prior to training. "
     "More details: "
-    "https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth"
-)
+    "https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth")
 flags.DEFINE_float(
     "l1_regularizer", _DEFAULT_HPARAMS.l1_regularizer,
     "Coefficient of L1 regularization applied on model weights.")
 flags.DEFINE_float(
     "l2_regularizer", _DEFAULT_HPARAMS.l2_regularizer,
-    "Coefficient of L2 regularization applied on model weights."
-)
+    "Coefficient of L2 regularization applied on model weights.")
 flags.DEFINE_float(
     "label_smoothing", _DEFAULT_HPARAMS.label_smoothing,
-    "Coefficient of label smoothing used in loss function."
-)
+    "Coefficient of label smoothing used in loss function.")
 flags.DEFINE_bool(
     "cache", _DEFAULT_HPARAMS.cache,
     "Cache datasets to speed up data loading. Set to true only if "
-    "your dataset is able to be loaded to the memory completely."
-)
+    "your dataset is able to be loaded to the memory completely.")
 flags.DEFINE_float(
     "validation_split", _DEFAULT_HPARAMS.validation_split,
-    "The fractin of the dataset splitted into a validation set"
-)
+    "The fractin of the dataset splitted into a validation set")
 flags.DEFINE_bool(
     "do_data_augmentation", _DEFAULT_HPARAMS.do_data_augmentation,
     "Whether do data augmentation on training set. "
-    "Can use default augmentation params or specifying them."
-)
+    "Can use default augmentation params or specifying them.")
 flags.DEFINE_integer(
     "rotation_range", _DEFAULT_HPARAMS.rotation_range,
-    "Degree range for random rotation."
-)
+    "Degree range for random rotation. The total range is [-range, range].")
 flags.DEFINE_bool(
     "horizontal_flip", _DEFAULT_HPARAMS.horizontal_flip,
-    "Horizontally flip images."
-)
+    "Horizontally flip images.")
 flags.DEFINE_float(
     "width_shift_range", _DEFAULT_HPARAMS.width_shift_range,
     "Shift images horizontally by pixels(if >=1) or by ratio(if <1).")
 flags.DEFINE_float(
     "height_shift_range", _DEFAULT_HPARAMS.height_shift_range,
-    "Shift images vertically by pixels(if >=1) or by ratio(if <1)."
-)
+    "Shift images vertically by pixels(if >=1) or by ratio(if <1).")
 flags.DEFINE_float(
     "shear_range", _DEFAULT_HPARAMS.shear_range,
-    "Shear angle in counter-clockwise direction in degrees."
-)
+    "Shear angle in counter-clockwise direction in degrees.")
 flags.DEFINE_float(
     "zoom_range", _DEFAULT_HPARAMS.zoom_range,
-    "Range for random zoom."
-)
+    "Range for random zoom. The total range is [-range, range].")
 flags.DEFINE_string(
     "strategy", "default",
     "Strategy for distributed training. Currently multi-GPU"
-    "(mirroredstrategy) and single CPU/GPU(default) are supported."
-)
+    "(mirroredstrategy) and single CPU/GPU(default) are supported.")
 FLAGS = flags.FLAGS
 
 

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier.py
@@ -122,11 +122,21 @@ flags.DEFINE_float(
     "Coefficient of L1 regularization applied on model weights.")
 flags.DEFINE_float(
     "l2_regularizer", _DEFAULT_HPARAMS.l2_regularizer,
-    "Coefficient of L2 regularization applied on model weights.")
-flags.DEFINE_float("label_smoothing", _DEFAULT_HPARAMS.label_smoothing,
-                   "Coefficient of label smoothing used in loss function.")
-flags.DEFINE_float("validation_split", _DEFAULT_HPARAMS.validation_split,
-                   "The fractin of the dataset splitted into a validation set")
+    "Coefficient of L2 regularization applied on model weights."
+)
+flags.DEFINE_float(
+    "label_smoothing", _DEFAULT_HPARAMS.label_smoothing,
+    "Coefficient of label smoothing used in loss function."
+)
+flags.DEFINE_bool(
+    "cache", _DEFAULT_HPARAMS.cache,
+    "Cache datasets to speed up data loading. Set to true only if"
+    "your dataset is able to be loaded to the memory completely."
+)
+flags.DEFINE_float(
+    "validation_split", _DEFAULT_HPARAMS.validation_split,
+    "The fractin of the dataset splitted into a validation set"
+)
 flags.DEFINE_bool(
     "do_data_augmentation", _DEFAULT_HPARAMS.do_data_augmentation,
     "Whether do data augmentation on training set."
@@ -140,11 +150,21 @@ flags.DEFINE_float(
     "Shift images horizontally by pixels(if >=1) or by ratio(if <1).")
 flags.DEFINE_float(
     "height_shift_range", _DEFAULT_HPARAMS.height_shift_range,
-    "Shift images vertically by pixels(if >=1) or by ratio(if <1).")
-flags.DEFINE_float("shear_range", _DEFAULT_HPARAMS.shear_range,
-                   "Shear angle in counter-clockwise direction in degrees.")
-flags.DEFINE_float("zoom_range", _DEFAULT_HPARAMS.zoom_range,
-                   "Range for random zoom.")
+    "Shift images vertically by pixels(if >=1) or by ratio(if <1)."
+)
+flags.DEFINE_float(
+    "shear_range", _DEFAULT_HPARAMS.shear_range,
+    "Shear angle in counter-clockwise direction in degrees."
+)
+flags.DEFINE_float(
+    "zoom_range", _DEFAULT_HPARAMS.zoom_range,
+    "Range for random zoom."
+)
+flags.DEFINE_string(
+    "strategy", "default",
+    "Strategy for distributed training. Currently multi-GPU"
+    "(mirroredstrategy) and single CPU/GPU(default) are supported."
+)
 FLAGS = flags.FLAGS
 
 
@@ -161,13 +181,15 @@ def _get_hparams_from_flags():
       l2_regularizer=FLAGS.l2_regularizer,
       label_smoothing=FLAGS.label_smoothing,
       validation_split=FLAGS.validation_split,
+      cache=FLAGS.cache,
       do_data_augmentation=FLAGS.do_data_augmentation,
       rotation_range=FLAGS.rotation_range,
       horizontal_flip=FLAGS.horizontal_flip,
       width_shift_range=FLAGS.width_shift_range,
       height_shift_range=FLAGS.height_shift_range,
       shear_range=FLAGS.shear_range,
-      zoom_range=FLAGS.zoom_range)
+      zoom_range=FLAGS.zoom_range,
+      strategy=FLAGS.strategy)
 
 
 def _check_keras_dependencies():

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -294,11 +294,11 @@ def _get_data_with_keras_new(image_dir, image_size, batch_size,
   # 8 * batch_size is a good choice for shuffle buffer size.
   buffer_size = batch_size * 8
   # shuffle here to avoid val dataset containing a single type of examples.
-  list_ds = tf.data.Dataset.list_files(str(image_dir/'*/*'))
+  list_ds = tf.data.Dataset.list_files(str(image_dir/'*/*'), shuffle=True)
   labeled_ds = list_ds.map(
       functools.partial(
           _process_path, image_size=image_size, class_names=class_names), 
-      num_parallel_calls=AUTOTUNE).shuffle(buffer_size=buffer_size)
+      num_parallel_calls=AUTOTUNE)
   valid_size = int(image_count * validation_split)
   train_size = image_count - valid_size
   valid_ds = labeled_ds.take(valid_size)

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -186,6 +186,7 @@ def _process_path(file_path, image_size, class_names):
   img = _decode_img(img, image_size)
   return img, label
 
+
 def _get_data_with_keras_new(image_dir, image_size, batch_size, 
                              validation_split, cache):
   """Gets training and validation data via keras_preprocessing.
@@ -309,8 +310,9 @@ def build_model(module_layer, hparams, image_size, num_classes,
   model = tf.keras.Sequential([
       tf.keras.Input(shape=(image_size[0], image_size[1], 3)),])
 
-  if do_data_augmentation:
-    # TODO(jin): seems preprocessing layers cannot be used inside a strategy.
+  if do_data_augmentation and False:
+    # TODO(jin): disable augmentation, since seems preprocessing layers cannot 
+    # be used inside a strategy.
     preprocessing = tf.keras.layers.experimental.preprocessing
     model.add(preprocessing.RandomRotation(factor=augment_params['rotation_range']))
     model.add(preprocessing.RandomWidth(factor=augment_params['width_shift_range']))
@@ -423,7 +425,11 @@ def make_image_classifier(tfhub_module, image_dir, hparams,
     print("Using module {} with image size {}".format( tfhub_module, image_size))
 
     train_data_and_size, valid_data_and_size, labels = _get_data_with_keras_new(
-        image_dir, image_size, hparams.batch_size, hparams.validation_split, hparams.cache)
+        image_dir, image_size, hparams.batch_size, hparams.validation_split, 
+        hparams.cache)
+    # train_data_and_size, valid_data_and_size, labels = _get_data_with_keras(
+    #     image_dir, image_size, hparams.batch_size, hparams.validation_split, 
+    #     hparams.do_data_augmentation, augment_params)
     print("Found", len(labels), "classes:", ", ".join(labels))
     print("Dataset size: %s (training) %s (validation)" % 
         (train_data_and_size[1], valid_data_and_size[1]))

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -239,8 +239,8 @@ def _get_data_with_keras(image_dir, image_size, batch_size,
   """
   AUTOTUNE = tf.data.experimental.AUTOTUNE
   image_dir = pathlib.Path(image_dir)
-  class_names = np.array([item.name for item in image_dir.glob('*') 
-                          if item.name != 'LICENSE.txt'])
+  class_names = tuple(item.name for item in image_dir.glob('*') 
+                      if item.is_dir())
   image_count = len(list(image_dir.glob('*/*')))
   # 8 * batch_size is a good choice for shuffle buffer size.
   buffer_size = batch_size * 8

--- a/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
+++ b/tensorflow_hub/tools/make_image_classifier/make_image_classifier_lib.py
@@ -256,27 +256,23 @@ def build_model(module_layer, hparams, image_size, num_classes,
   model = tf.keras.Sequential([
       tf.keras.Input(shape=(image_size[0], image_size[1], 3)),])
 
-  aug_preprocessor = None
   if do_data_augmentation:
+    # TODO(jin): seems preprocessing layers cannot be used inside a strategy.
     preprocessing = tf.keras.layers.experimental.preprocessing
-    aug_preprocessor = tf.keras.Sequential(
-      preprocessing.RandomRotation(factor=augment_params['rotation_range']),
-      preprocessing.RandomWidth(factor=augment_params['width_shift_range']),
-      preprocessing.RandomHeight(factor=augment_params['height_shift_range']),
-      preprocessing.RandomZoom(factor=augment_params['zoom_range']),
-      preprocessing.RandomFlip(mode='horizontal')
-    )
-    model.add(aug_preprocessor)
+    model.add(preprocessing.RandomRotation(factor=augment_params['rotation_range']))
+    model.add(preprocessing.RandomWidth(factor=augment_params['width_shift_range']))
+    model.add(preprocessing.RandomHeight(factor=augment_params['height_shift_range']))
+    model.add(preprocessing.RandomZoom(factor=augment_params['zoom_range']))
+    model.add(preprocessing.RandomFlip(mode='horizontal'))
 
-  model.add(tf.keras.Sequential([
-      module_layer,
-      tf.keras.layers.Dropout(rate=hparams.dropout_rate),
-      tf.keras.layers.Dense(
-          num_classes,
-          activation="softmax",
-          kernel_regularizer=tf.keras.regularizers.l1_l2(
-              l1=hparams.l1_regularizer, l2=hparams.l2_regularizer))
-  ])
+  model.add(module_layer)
+  model.add(tf.keras.layers.Dropout(rate=hparams.dropout_rate))
+  model.add(tf.keras.layers.Dense(
+      num_classes,
+      activation="softmax",
+      kernel_regularizer=tf.keras.regularizers.l1_l2(l1=hparams.l1_regularizer,
+                                                     l2=hparams.l2_regularizer)))
+
   print(model.summary())
   return model
 


### PR DESCRIPTION
This PR includes:

- Replaces the `ImageDataGenerator` with `tf.data.Dataset` pipeline, leading to a large speedup.
- Add distribute strategy support. Currently the `OneDeviceStrategy` is the default strategy (either GPU or CPU, depending on if there is GPU available), and one can choose the `MirroredStrategy` to use multi-GPU training.
- Currently, the `tf.data.Dataset` pipeline only supports flip, rotate, zoom.

