### PR TITLE
Adding int8 and float16 quantized TF lite models for DeepLab (COCO)

### DIFF
--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
@@ -8,12 +8,12 @@ Lightweight deep learning model for semantic image segmentation.
 DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
 
 ### Note
-- The TensorFlow Lite model was converted using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization). 
-- The TensorFlow Lite model was converted from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 
+- The TensorFlow Lite model was generated using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
 
 ### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance. 
+Thanks to Khanh LeViet for his constant guidance.
 
 References
 --------------

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2-float16/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2-float16/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_coco_voctrainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization). 
+- The TensorFlow Lite model was converted from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/1.md
@@ -1,20 +1,9 @@
-# Lite sayakpaul/deeplabv3-mobilenetv2-float16/1/default/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2-float16/1
 Lightweight deep learning model for semantic image segmentation.
 
-<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2-float16/1 -->
-<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_coco_voctrainval_tflite.tar.gz -->
-
-### Overview
-DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
-
-### Note
-- The TensorFlow Lite model was generated using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
-- The TensorFlow Lite model was generated from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
-
-### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance.
-
-References
---------------
-[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- dataset: PASCAL VOC 2012 -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/default/lite/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-float16/default/lite/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2-float16/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2-float16/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/float16_mobilenetv2_coco_voctrainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was generated using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
@@ -8,12 +8,12 @@ Lightweight deep learning model for semantic image segmentation.
 DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
 
 ### Note
-- The TensorFlow Lite model was converted using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization). 
-- The TensorFlow Lite model was converted from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 
+- The TensorFlow Lite model was generated using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
 
 ### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance. 
+Thanks to Khanh LeViet for his constant guidance.
 
 References
 --------------

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2-int8/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2-int8/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_coco_voctrainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization). 
+- The TensorFlow Lite model was converted from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md). 
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance. 
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/1.md
@@ -1,20 +1,9 @@
-# Lite sayakpaul/deeplabv3-mobilenetv2-int8/1/default/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2-int8/1
 Lightweight deep learning model for semantic image segmentation.
 
-<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2-int8/1 -->
-<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_coco_voctrainval_tflite.tar.gz -->
-
-### Overview
-DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
-
-### Note
-- The TensorFlow Lite model was generated using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
-- The TensorFlow Lite model was generated from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
-
-### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance.
-
-References
---------------
-[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
+<!-- dataset: PASCAL VOC 2012 -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/default/lite/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-int8/default/lite/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2-int8/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2-int8/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_coco_voctrainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was generated using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).


### PR DESCRIPTION
A brief description of the previous TF Lite model is available [here](https://github.com/tensorflow/hub/blob/master/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/default/lite/1.md). This PR adds int8 and float16 TF Lite models that allow us to take advantage of the hardware accelerators supported by TF Lite. 