### PR TITLE
Adding deeplab-mobilenetv2_dm05 models

### DIFF
--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-ade20k/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-ade20k/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
 <!-- dataset: ADE20k -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-xception65/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2-xception65/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (xception65_ade20k_train) -->
 <!-- dataset: ADE20k -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (mobilenetv2_coco_voc_trainval) -->
 <!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/f16_mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
+- The TensorFlow Lite model was converted from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -8,8 +8,8 @@ Lightweight deep learning model for semantic image segmentation.
 DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
 
 ### Note
-- The TensorFlow Lite model was converted using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
-- The TensorFlow Lite model was converted from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- The TensorFlow Lite model was generated using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
 - Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
 
 ### Acknowledgements

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
 <!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -1,9 +1,9 @@
-# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05/1
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
-<!-- dataset: ADE20k -->
+<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -1,20 +1,9 @@
-# Lite sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1/default/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1
 Lightweight deep learning model for semantic image segmentation.
 
-<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1 -->
-<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/f16_mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
-
-### Overview
-DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
-
-### Note
-- The TensorFlow Lite model was generated using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
-- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
-
-### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance.
-
-References
---------------
-[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
+<!-- dataset: ADE20k -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1.md
@@ -1,4 +1,4 @@
-# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/default/lite/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-float16/default/lite/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05-float16/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/f16_mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was generated using the post-training `float16` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#float16_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -1,9 +1,9 @@
-# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05/1
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
-<!-- dataset: ADE20k -->
+<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -1,20 +1,9 @@
-# Lite sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1/default/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1
 Lightweight deep learning model for semantic image segmentation.
 
-<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1 -->
-<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
-
-### Overview
-DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
-
-### Note
-- The TensorFlow Lite model was generated using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
-- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
-
-### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance.
-
-References
---------------
-[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
+<!-- dataset: ADE20k -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
 <!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -8,8 +8,8 @@ Lightweight deep learning model for semantic image segmentation.
 DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
 
 ### Note
-- The TensorFlow Lite model was converted using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
-- The TensorFlow Lite model was converted from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- The TensorFlow Lite model was generated using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
 - Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
 
 ### Acknowledgements

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- The TensorFlow Lite model was converted from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1.md
@@ -1,4 +1,4 @@
-# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/default/lite/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05-int8/default/lite/1.md
@@ -1,0 +1,20 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05-int8/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.3.0/int8_mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was generated using the post-training `int8` quantization method as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
@@ -1,0 +1,19 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2_dm05/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was converted from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
@@ -8,7 +8,7 @@ Lightweight deep learning model for semantic image segmentation.
 DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
 
 ### Note
-- The TensorFlow Lite model was converted from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
 - Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
 
 ### Acknowledgements

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
 <!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
@@ -1,19 +1,9 @@
-# Lite sayakpaul/deeplabv3-mobilenetv2_dm05/1/default/1
+# Placeholder sayakpaul/deeplabv3-mobilenetv2_dm05/1
 Lightweight deep learning model for semantic image segmentation.
 
-<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05/1 -->
-<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
-
-### Overview
-DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
-
-### Note
-- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
-- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
-
-### Acknowledgements
-Thanks to Khanh LeViet for his constant guidance.
-
-References
---------------
-[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).
+<!-- module-type: image-segmentation -->
+<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
+<!-- dataset: ADE20k -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/1.md
@@ -2,8 +2,8 @@
 Lightweight deep learning model for semantic image segmentation.
 
 <!-- module-type: image-segmentation -->
-<!-- network-architecture: DeepLab (mobilenetv2_ade20k_train) -->
-<!-- dataset: ADE20k -->
+<!-- network-architecture: DeepLab (mobilenetv2_dm05_coco_voc_trainval) -->
+<!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
 <!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/default/lite/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv2_dm05/default/lite/1.md
@@ -1,0 +1,19 @@
+# Lite sayakpaul/deeplabv3-mobilenetv2_dm05/1/default/1
+Lightweight deep learning model for semantic image segmentation.
+
+<!-- parent-model: sayakpaul/deeplabv3-mobilenetv2_dm05/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.1.0/mobilenetv2_dm05_coco_voc_trainval_tflite.tar.gz -->
+
+### Overview
+DeepLab is a state-of-art deep learning model for semantic image segmentation, where the goal is to assign semantic labels (e.g. person, dog, cat) to every pixel in the input image. It was published in [1].
+
+### Note
+- The TensorFlow Lite model was generated from [`mobilenetv2_dm05_coco_voc_trainval`](http://download.tensorflow.org/models/deeplabv3_mnv2_dm05_pascal_trainval_2018_10_01.tar.gz) checkpoint. More information about the different DeepLabV3 checkpoints is available [here](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md).
+- Example usage and TensorFlow Lite conversion process are demonstrated in this [Colab Notebook](https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb).
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] [Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1802.02611).

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv3-cityscapes/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-mobilenetv3-cityscapes/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (mobilenetv3_large_cityscapes_trainfine) -->
 <!-- dataset: CityScapes -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/deeplabv3-xception65/1.md
+++ b/tfhub_dev/assets/sayakpaul/deeplabv3-xception65/1.md
@@ -5,5 +5,4 @@ Lightweight deep learning model for semantic image segmentation.
 <!-- network-architecture: DeepLab (xception65_coco_voc_trainaug) -->
 <!-- dataset: PASCAL VOC 2012 -->
 <!-- fine-tunable: false -->
-<!-- language: en -->
 <!-- license: Apache-2.0 -->


### PR DESCRIPTION
These TF Lite models are by far the fastest ones for doing semantic segmentation but that comes at the cost of sacrificing the quality a bit. 