### PR TITLE
Adding inceptionv3 based style transfer models (TF Lite)

### DIFF
--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/1.md
@@ -1,0 +1,9 @@
+# Placeholder sayakpaul/arbitrary-image-stylization-inceptionv3/1
+Fast arbitrary image style transfer based on an InceptionV3 backbone.
+
+<!-- dataset: Multiple -->
+<!-- module-type: image-style-transfer -->
+<!-- network-architecture: Other -->
+<!-- fine-tunable: false -->
+<!-- language: en -->
+<!-- license: Apache-2.0 -->

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
@@ -1,0 +1,29 @@
+# Lite sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1
+TF Lite quantized prediction part of the Arbitrary Style Transfer model.
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+
+<!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_hybrid_tflite.tar.gz -->
+
+### Overview
+The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
+
+This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].
+
+### Note
+- The TensorFlow Lite models were generated from InceptionV3 based model that produces higher quality stylized images at the expense of latency. For faster TensorFlow Lite models, check out [these](https://tfhub.dev/google/magenta/arbitrary-image-stylization-v1-256/2).
+- Models were quantized using _dynamic range quantization_ as described [here](https://www.tensorflow.org/lite/performance/post_training_quant).
+- This [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Magenta_arbitrary_style_transfer_model_conversion.ipynb) shows the TensorFLow Lite model conversion process (includes three different post-training quantization schemes).
+
+### Example use
+For a good understanding of the model usage follow the
+[sample app](https://github.com/tensorflow/examples/blob/master/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/StyleTransferModelExecutor.kt)
+usage.
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] Golnaz Ghiasi, Honglak Lee, Manjunath Kudlur, Vincent Dumoulin, Jonathon Shlens. [Exploring the structure of a real-time, arbitrary neural artistic stylization network](https://arxiv.org/abs/1705.06830). Proceedings of the British Machine Vision Conference (BMVC), 2017.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
@@ -1,10 +1,10 @@
 # Lite sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1
 TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
-
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_hybrid_tflite.tar.gz -->
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
@@ -4,7 +4,7 @@ TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_hybrid_tflite.tar.gz -->
 
-[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/predict/1.md
@@ -4,7 +4,7 @@ TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_hybrid_tflite.tar.gz -->
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
@@ -1,0 +1,29 @@
+# Lite sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1
+TF Lite quantized transfer part of the Arbitrary Style Transfer model.
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+
+<!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_hybrid_tflite.tar.gz -->
+
+### Overview
+The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
+
+This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].
+
+### Note
+- The TensorFlow Lite models were generated from InceptionV3 based model that produces higher quality stylized images at the expense of latency. For faster TensorFlow Lite models, check out [these](https://tfhub.dev/google/magenta/arbitrary-image-stylization-v1-256/2).
+- Models were quantized using _dynamic range quantization_ as described [here](https://www.tensorflow.org/lite/performance/post_training_quant).
+- This [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Magenta_arbitrary_style_transfer_model_conversion.ipynb) shows the TensorFLow Lite model conversion process (includes three different post-training quantization schemes).
+
+### Example use
+For a good understanding of the model usage follow the
+[sample app](https://github.com/tensorflow/examples/blob/master/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/StyleTransferModelExecutor.kt)
+usage.
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] Golnaz Ghiasi, Honglak Lee, Manjunath Kudlur, Vincent Dumoulin, Jonathon Shlens. [Exploring the structure of a real-time, arbitrary neural artistic stylization network](https://arxiv.org/abs/1705.06830). Proceedings of the British Machine Vision Conference (BMVC), 2017.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
@@ -4,7 +4,7 @@ TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_hybrid_tflite.tar.gz -->
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
@@ -4,7 +4,7 @@ TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_hybrid_tflite.tar.gz -->
 
-[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1.md
@@ -1,10 +1,10 @@
 # Lite sayakpaul/arbitrary-image-stylization-inceptionv3/dr/transfer/1
 TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
-
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_hybrid_tflite.tar.gz -->
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
@@ -1,0 +1,29 @@
+# Lite sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1
+TF Lite quantized prediction part of the Arbitrary Style Transfer model.
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+
+<!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_f16_tflite.tar.gz -->
+
+### Overview
+The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
+
+This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].
+
+### Note
+- The TensorFlow Lite models were generated from InceptionV3 based model that produces higher quality stylized images at the expense of latency. For faster TensorFlow Lite models, check out [these](https://tfhub.dev/google/magenta/arbitrary-image-stylization-v1-256/2).
+- Models were quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Magenta_arbitrary_style_transfer_model_conversion.ipynb) shows the TensorFLow Lite model conversion process (includes three different post-training quantization schemes).
+
+### Example use
+For a good understanding of the model usage follow the
+[sample app](https://github.com/tensorflow/examples/blob/master/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/StyleTransferModelExecutor.kt)
+usage.
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] Golnaz Ghiasi, Honglak Lee, Manjunath Kudlur, Vincent Dumoulin, Jonathon Shlens. [Exploring the structure of a real-time, arbitrary neural artistic stylization network](https://arxiv.org/abs/1705.06830). Proceedings of the British Machine Vision Conference (BMVC), 2017.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
@@ -4,7 +4,7 @@ TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_f16_tflite.tar.gz -->
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
@@ -1,10 +1,10 @@
 # Lite sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1
 TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
-
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_f16_tflite.tar.gz -->
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/predict/1.md
@@ -4,7 +4,7 @@ TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_f16_tflite.tar.gz -->
 
-[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
@@ -4,7 +4,7 @@ TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_f16_tflite.tar.gz -->
 
-[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
@@ -1,0 +1,29 @@
+# Lite sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1
+TF Lite quantized transfer part of the Arbitrary Style Transfer model.
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+
+<!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_f16_tflite.tar.gz -->
+
+### Overview
+The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
+
+This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].
+
+### Note
+- The TensorFlow Lite models were generated from InceptionV3 based model that produces higher quality stylized images at the expense of latency. For faster TensorFlow Lite models, check out [these](https://tfhub.dev/google/magenta/arbitrary-image-stylization-v1-256/2).
+- Models were quantized using `float16` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_float16_quant).
+- This [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Magenta_arbitrary_style_transfer_model_conversion.ipynb) shows the TensorFLow Lite model conversion process (includes three different post-training quantization schemes).
+
+### Example use
+For a good understanding of the model usage follow the
+[sample app](https://github.com/tensorflow/examples/blob/master/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/StyleTransferModelExecutor.kt)
+usage.
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] Golnaz Ghiasi, Honglak Lee, Manjunath Kudlur, Vincent Dumoulin, Jonathon Shlens. [Exploring the structure of a real-time, arbitrary neural artistic stylization network](https://arxiv.org/abs/1705.06830). Proceedings of the British Machine Vision Conference (BMVC), 2017.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
@@ -4,7 +4,7 @@ TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_f16_tflite.tar.gz -->
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1.md
@@ -1,10 +1,10 @@
 # Lite sayakpaul/arbitrary-image-stylization-inceptionv3/fp16/transfer/1
 TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
-
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_f16_tflite.tar.gz -->
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
@@ -4,7 +4,7 @@ TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_int8_tflite.tar.gz -->
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
@@ -1,0 +1,29 @@
+# Lite sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1
+TF Lite quantized prediction part of the Arbitrary Style Transfer model.
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+
+<!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_int8_tflite.tar.gz -->
+
+### Overview
+The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
+
+This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].
+
+### Note
+- The TensorFlow Lite models were generated from InceptionV3 based model that produces higher quality stylized images at the expense of latency. For faster TensorFlow Lite models, check out [these](https://tfhub.dev/google/magenta/arbitrary-image-stylization-v1-256/2).
+- Models were quantized using `int8` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- This [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Magenta_arbitrary_style_transfer_model_conversion.ipynb) shows the TensorFLow Lite model conversion process (includes three different post-training quantization schemes).
+
+### Example use
+For a good understanding of the model usage follow the
+[sample app](https://github.com/tensorflow/examples/blob/master/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/StyleTransferModelExecutor.kt)
+usage.
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] Golnaz Ghiasi, Honglak Lee, Manjunath Kudlur, Vincent Dumoulin, Jonathon Shlens. [Exploring the structure of a real-time, arbitrary neural artistic stylization network](https://arxiv.org/abs/1705.06830). Proceedings of the British Machine Vision Conference (BMVC), 2017.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
@@ -4,7 +4,7 @@ TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_int8_tflite.tar.gz -->
 
-[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1.md
@@ -1,10 +1,10 @@
 # Lite sayakpaul/arbitrary-image-stylization-inceptionv3/int8/predict/1
 TF Lite quantized prediction part of the Arbitrary Style Transfer model.
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
-
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_predict_int8_tflite.tar.gz -->
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
@@ -4,9 +4,9 @@ TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_int8_tflite.tar.gz -->
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
-### Overview
+### Overviews
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
 
 This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
@@ -1,0 +1,29 @@
+# Lite sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1
+TF Lite quantized transfer part of the Arbitrary Style Transfer model.
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+
+<!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
+<!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_int8_tflite.tar.gz -->
+
+### Overview
+The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.
+
+This module performs fast artistic style transfer that may work on arbitrary painting styles as described in [1].
+
+### Note
+- The TensorFlow Lite models were generated from InceptionV3 based model that produces higher quality stylized images at the expense of latency. For faster TensorFlow Lite models, check out [these](https://tfhub.dev/google/magenta/arbitrary-image-stylization-v1-256/2).
+- Models were quantized using `int8` quantization as described [here](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization).
+- This [Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Magenta_arbitrary_style_transfer_model_conversion.ipynb) shows the TensorFLow Lite model conversion process (includes three different post-training quantization schemes).
+
+### Example use
+For a good understanding of the model usage follow the
+[sample app](https://github.com/tensorflow/examples/blob/master/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/StyleTransferModelExecutor.kt)
+usage.
+
+### Acknowledgements
+Thanks to Khanh LeViet for his constant guidance.
+
+References
+--------------
+[1] Golnaz Ghiasi, Honglak Lee, Manjunath Kudlur, Vincent Dumoulin, Jonathon Shlens. [Exploring the structure of a real-time, arbitrary neural artistic stylization network](https://arxiv.org/abs/1705.06830). Proceedings of the British Machine Vision Conference (BMVC), 2017.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
@@ -4,7 +4,7 @@ TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_int8_tflite.tar.gz -->
 
-[![Open Colab notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
+[![Open Colab notebook]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overviews
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.

--- a/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
+++ b/tfhub_dev/assets/sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1.md
@@ -1,10 +1,10 @@
 # Lite sayakpaul/arbitrary-image-stylization-inceptionv3/int8/transfer/1
 TF Lite quantized transfer part of the Arbitrary Style Transfer model.
 
-[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
-
 <!-- parent-model: sayakpaul/arbitrary-image-stylization-inceptionv3/1 -->
 <!-- asset-path: https://github.com/sayakpaul/Adventures-in-TensorFlow-Lite/releases/download/v0.4.0/style_transfer_int8_tflite.tar.gz -->
+
+[![Open Colab Notebok]](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/Style_Transfer_Demo_InceptionV3.ipynb)
 
 ### Overview
 The original work for artistic style transfer with neural networks proposed a slow optimization algorithm that works on any arbitrary painting. Subsequent work developed a method for fast artistic style transfer that may operate in real time, but was limited to one or a limited set of styles.


### PR DESCRIPTION
[The existing TensorFlow Lite models on TF Hub for image stylization](https://tfhub.dev/google/lite-model/magenta/arbitrary-image-stylization-v1-256/fp16/prediction/1) are based on a MobileNetV2 backbone. The models present in this PR are based on an InceptionV3 based backbone that further improves the quality of the images. 