### PR TITLE
Added MiDaS v2 (monocular depth estimation from a single RGB image)

### DIFF
--- a/tfhub_dev/assets/intel/intel.md
+++ b/tfhub_dev/assets/intel/intel.md
@@ -1,0 +1,12 @@
+# Publisher intel
+Intel
+
+[![Icon URL]](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/Intel-logo.svg/248px-Intel-logo.svg.png)
+
+## [Intel](https://intel.com)
+Intel Corporation is an American multinational corporation and technology company headquartered in Santa Clara, California, in Silicon Valley. 
+It is the world's largest and highest valued semiconductor chip manufacturer based on revenue, and is the inventor of the x86 series of microprocessors, 
+the processors found in most personal computers (PCs). 
+Intel ranked No. 46 in the 2018 Fortune 500 list of the largest United States corporations by total revenue. Intel is incorporated in Delaware.
+Intel Corporation was founded on July 18, 1968, by semiconductor pioneers Robert Noyce and Gordon Moore (of Moore's law), 
+and is associated with the executive leadership and vision of Andrew Grove.

--- a/tfhub_dev/assets/intel/midas/v2/1/1.md
+++ b/tfhub_dev/assets/intel/midas/v2/1/1.md
@@ -1,0 +1,81 @@
+# Module intel/midas/v2/1
+Convolutional neural network for monocular depth estimation from a single RGB image.
+
+<!-- asset-path: https://github.com/intel-isl/MiDaS/releases/download/v2/model_hub.tar.gz -->
+<!-- module-type: image-depth-estimation -->
+<!-- network-architecture: MiDaS -->
+<!-- dataset: DIML Indoo, MegaDepth, ReDWeb, WSVD, 3D Movies -->
+<!-- fine-tunable: false  -->
+<!-- format: hub -->
+<!-- license: MIT -->
+
+## License
+MIT License
+
+## Qualitative Information
+
+This MiDaS model is converted from the original version of the [MiDaS model](https://github.com/intel-isl/MiDaS). 
+MiDaS was first introduced by
+Rene Ranftl, Katrin Lasinger, David Hafner, Konrad Schindler, Vladlen Koltun in the paper:
+[Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer](https://arxiv.org/abs/1907.01341).
+
+#### Requirements
+
+```
+pip install tensorflow tensorflow-hub opencv-python
+```
+
+* required nVidia GPU
+
+#### Model Details
+This module is based on a Pytorch version of MiDaS, which performs efficiently and with very high accuracy to compute depth from a single image.
+
+* input: (uint8) RGB image with shape (3, 384, 384)
+* output: (float32) inverse depth maps (1, 384, 384)
+
+#### Example Use
+
+```python
+import os
+import glob
+import cv2
+import numpy as np
+
+import tensorflow as tf
+import tensorflow_hub as hub
+
+# the runtime initialization will not allocate all memory on the device to avoid out of GPU memory
+gpus = tf.config.experimental.list_physical_devices('GPU')
+for gpu in gpus:
+    #tf.config.experimental.set_memory_growth(gpu, True)
+    tf.config.experimental.set_virtual_device_configuration(gpu,
+    [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=4000)])
+
+# input
+img = cv2.imread('dog.jpg')
+img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) / 255.0
+
+img_resized = tf.image.resize(img, [384,384], method='bicubic', preserve_aspect_ratio=False)
+img_resized = tf.transpose(img_resized, [2, 0, 1])
+img_input = img_resized.numpy()
+reshape_img = img_input.reshape(1,3,384,384)
+tensor = tf.convert_to_tensor(reshape_img, dtype=tf.float32)
+
+# load model
+module = hub.load("https://tfhub.dev/intel/midas/v2/1", tags=['serve'])
+output = module.signatures['serving_default'](tensor)
+prediction = output['default'].numpy()
+prediction = prediction.reshape(384, 384)
+             
+# output file
+prediction = cv2.resize(prediction, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_CUBIC)
+print(" Write image to: output.png")
+depth_min = prediction.min()
+depth_max = prediction.max()
+img_out = (255 * (prediction - depth_min) / (depth_max - depth_min)).astype("uint8")
+cv2.imwrite("output.png", img_out)
+
+```
+
+
+**Source:** https://github.com/intel-isl/MiDaS


### PR DESCRIPTION
Convolutional neural network for monocular depth estimation from a single RGB image.

* Paper: https://arxiv.org/abs/1907.01341
* Original repository: https://github.com/intel-isl/MiDaS
* Passed tests: https://colab.research.google.com/gist/AlexeyAB/93431ab2fcd431508643acfab04ee067/test_pr_tf_hub.ipynb

----

What does it do:

* Original 1 image

![dog](https://user-images.githubusercontent.com/4096485/88069780-96857a00-cb7a-11ea-9c86-596275099eaf.jpg)


* Output image with depth

![output](https://user-images.githubusercontent.com/4096485/88069765-91c0c600-cb7a-11ea-895b-047e49cf7e5c.png)
