### PR TITLE
Add sample Android app for chest-xray-covid

### DIFF
--- a/tfhub_dev/assets/rishit-dagli/chest-xray-covid/default/lite/1.md
+++ b/tfhub_dev/assets/rishit-dagli/chest-xray-covid/default/lite/1.md
@@ -21,6 +21,8 @@ The model returns a tensor of `scores` with score for each label
 
 #### Example Usage
 
+A sample usage of the model with an Android app using the ML Model Binding Plugin can be found [here](https://github.com/Rishit-dagli/Code-to-Learn-2020/releases/download/v1.0.0/android_demo.tar.gz) .
+
 Java code:
 
 ```java


### PR DESCRIPTION
Added a minimalistic sample Android app for [chest-xray-covid](https://tfhub.dev/rishit-dagli/lite-model/chest-xray-covid/1/default/1) model. 

Build and APK Generation status - ![Build Covid Detector](https://github.com/Rishit-dagli/Code-to-Learn-2020/workflows/Build%20Covid%20Detector/badge.svg)
