### PR TITLE
Fix minor typo in docs

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -3,17 +3,17 @@
 # Model hosting protocol
 
 This document describes the URL coventions used when hosting all model types on
-[thub.dev](https://tfhub.dev) - TFJS, TF Lite and TensorFlow models. It also
+[tfhub.dev](https://tfhub.dev) - TFJS, TF Lite and TensorFlow models. It also
 describes describes the HTTP(S)-based protocol implemented by the
 `tensorflow_hub` library in order to load TensorFlow models from
-[thub.dev](https://tfhub.dev) and compatibe services into TensorFlow programs.
+[tfhub.dev](https://tfhub.dev) and compatibe services into TensorFlow programs.
 
 Its key feature is to use the same URL in code to load a model and in a browser
 to view the model documentation.
 
 ## General URL conventions
 
-[thub.dev](https://tfhub.dev) supports the following URL formats:
+[tfhub.dev](https://tfhub.dev) supports the following URL formats:
 
 *   TF Hub publishers follow `https://tfhub.dev/<publisher>`
 *   TF Hub collections follow
@@ -24,7 +24,7 @@ to view the model documentation.
     version of the model.
 
 TF Hub models can be downloaded as compressed assets by appending URL parameters
-to the [thub.dev](https://tfhub.dev) model URL. However, the URL paramters
+to the [tfhub.dev](https://tfhub.dev) model URL. However, the URL paramters
 required to achieve that depend on the model type:
 
 *   TensorFlow models (both SavedModel and TF1 Hub formats): append
@@ -103,7 +103,7 @@ locally may increase latency.
 
 ## tensorflow_hub library protocol
 
-This section describes how we host models on [thub.dev](https://tfhub.dev) for
+This section describes how we host models on [tfhub.dev](https://tfhub.dev) for
 use with the tensorflow_hub library. If you want to host your own model
 repository to work with the tensorflow_hub library, your HTTP(s) distribution
 service should provide an implementation of this protocol.
@@ -112,7 +112,7 @@ Note that this section does not address hosting TF Lite and TFJS models since
 they are not downloaded via the `tensorflow_hub` library. For more information
 on hosting these model types, please check [above](#general-url-conventions).
 
-Models are stored on [thub.dev](https://tfhub.dev) as compressed tar.gz files.
+Models are stored on [tfhub.dev](https://tfhub.dev) as compressed tar.gz files.
 The tensorflow_hub library automatically downloads the compressed model. They
 can also be manually downloaded by appending the `?tf-hub-format=compressed` to
 the model url, for example:

--- a/docs/model_formats.md
+++ b/docs/model_formats.md
@@ -2,13 +2,13 @@
 
 # Model formats
 
-[thub.dev](https://tfhub.dev) hosts the following model formats: SavedModel, TF1
+[tfhub.dev](https://tfhub.dev) hosts the following model formats: SavedModel, TF1
 Hub format, TF.js and TFLite. This page provides an overview of each model
 format.
 
 ## TensorFlow formats
 
-[thub.dev](https://tfhub.dev) hosts TensorFlow models in the SavedModel format
+[tfhub.dev](https://tfhub.dev) hosts TensorFlow models in the SavedModel format
 and TF1 Hub format. We recommend using models in the standardized SavedModel
 format instead of the deprecated TF1 Hub format when possible.
 
@@ -19,7 +19,7 @@ learn more about the SavedModel format in the
 [TensorFlow SavedModel](https://www.tensorflow.org/guide/saved_model) guide.
 
 You can browse SavedModels on tfhub.dev by using the TF2 version filter on the
-[thub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or by
+[tfhub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or by
 following
 [this link](https://tfhub.dev/s?subtype=module,placeholder&tf-version=tf2).
 
@@ -44,7 +44,7 @@ absence of the `tfhub_module.pb` file.
 
 You can browse models in the TF1 Hub format on tfhub.dev by using the TF1
 version filter on the
-[thub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or by
+[tfhub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or by
 following
 [this link](https://tfhub.dev/s?subtype=module,placeholder&tf-version=tf1).
 
@@ -61,7 +61,7 @@ The TFLite format is used for on-device inference. You can learn more at the
 
 You can browse TF Lite models on tfhub.dev by using the TF Lite model format
 filter on the
-[thub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or by
+[tfhub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or by
 following [this link](https://tfhub.dev/lite).
 
 ## TFJS format
@@ -70,5 +70,5 @@ The TF.js format is used for in-browser ML. You can learn more at the
 [TF.js documentation](https://www.tensorflow.org/js).
 
 You can browse TF.js models on tfhub.dev by using the TF.js model format filter
-on the [thub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or
+on the [tfhub.dev browse page](https://tfhub.dev/s?subtype=module,placeholder) or
 by following [this link](https://tfhub.dev/js).


### PR DESCRIPTION
Changes

- [x] Fix minor typo from `thub.dev` to `tfhub.dev` in docs - `hosting.md` and `model_formats.md`.

Notes

- [x] Submitted the Google Individual Contributor License Agreement. I'm new to this process, hope I've followed it correctly. Please let me know in case I'm missing something here.

![Screenshot 2020-10-25 at 6 06 47 PM](https://user-images.githubusercontent.com/4667864/97107315-eaa97880-16ec-11eb-88ea-c1ca5a1125fe.png)
