### PR TITLE
docs: fix simple typo, signartures -> signatures

### DIFF
--- a/docs/tf1_hub_module.md
+++ b/docs/tf1_hub_module.md
@@ -80,7 +80,7 @@ handle additional outputs gracefully.
 ### Trying out alternative modules
 
 Whenever there are multiple modules for the same task, TensorFlow Hub
-encourages to equip them with compatible signartures (interfaces)
+encourages to equip them with compatible signatures (interfaces)
 such that trying different ones is as easy as varying the module handle
 as a string-valued hyperparameter.
 


### PR DESCRIPTION
There is a small typo in docs/tf1_hub_module.md.

Should read `signatures` rather than `signartures`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md