### PR TITLE
Fix korean language mistake in the MUSE colab.

### DIFF
--- a/examples/colab/cross_lingual_similarity_with_tf_hub_multilingual_universal_encoder.ipynb
+++ b/examples/colab/cross_lingual_similarity_with_tf_hub_multilingual_universal_encoder.ipynb
@@ -266,7 +266,7 @@
         "german_sentences = ['Hund', 'Welpen sind nett.', 'Ich genieße lange Spaziergänge am Strand entlang mit meinem Hund.']\n",
         "italian_sentences = ['cane', 'I cuccioli sono carini.', 'Mi piace fare lunghe passeggiate lungo la spiaggia con il mio cane.']\n",
         "japanese_sentences = ['犬', '子犬はいいです', '私は犬と一緒にビーチを散歩するのが好きです']\n",
-        "korean_sentences = ['개', '강아지가 좋다.', '나는 나의 개를 해변을 따라 길게 산책하는 것을 즐긴다.']\n",
+        "korean_sentences = ['개', '강아지가 좋다.', '나는 나의 개와 해변을 따라 길게 산책하는 것을 즐긴다.']\n",
         "russian_sentences = ['собака', 'Милые щенки.', 'Мне нравится подолгу гулять по пляжу со своей собакой.']\n",
         "spanish_sentences = ['perro', 'Los cachorros son agradables.', 'Disfruto de dar largos paseos por la playa con mi perro.']\n",
         "\n",

--- a/examples/colab/cross_lingual_similarity_with_tf_hub_multilingual_universal_encoder.ipynb
+++ b/examples/colab/cross_lingual_similarity_with_tf_hub_multilingual_universal_encoder.ipynb
@@ -266,7 +266,7 @@
         "german_sentences = ['Hund', 'Welpen sind nett.', 'Ich genieße lange Spaziergänge am Strand entlang mit meinem Hund.']\n",
         "italian_sentences = ['cane', 'I cuccioli sono carini.', 'Mi piace fare lunghe passeggiate lungo la spiaggia con il mio cane.']\n",
         "japanese_sentences = ['犬', '子犬はいいです', '私は犬と一緒にビーチを散歩するのが好きです']\n",
-        "korean_sentences = ['개', '강아지가 좋다.', '나는 나의 산책을 해변을 따라 길게 산책하는 것을 즐긴다.']\n",
+        "korean_sentences = ['개', '강아지가 좋다.', '나는 나의 개를 해변을 따라 길게 산책하는 것을 즐긴다.']\n",
         "russian_sentences = ['собака', 'Милые щенки.', 'Мне нравится подолгу гулять по пляжу со своей собакой.']\n",
         "spanish_sentences = ['perro', 'Los cachorros son agradables.', 'Disfruto de dar largos paseos por la playa con mi perro.']\n",
         "\n",


### PR DESCRIPTION
The word should be 개와, for "with dog", not 산책을.

The similarity score compared to english improves from .766 to .793 after making this change.