### PR TITLE
Fix naming of TFHUB_CACHE_DIR environment variable in docs

### DIFF
--- a/tensorflow_hub/module_v2.py
+++ b/tensorflow_hub/module_v2.py
@@ -27,7 +27,7 @@ def resolve(handle):
   format.
 
   Resolves a module handle into a path by downloading and caching in
-  location specified by TF_HUB_CACHE_DIR if needed.
+  location specified by TFHUB_CACHE_DIR if needed.
 
   Currently, three types of module handles are supported:
     1) Smart URL resolvers such as tfhub.dev, e.g.:


### PR DESCRIPTION
The environment variable to set the cache directory is called `TFHUB_CACHE_DIR`.

See: https://github.com/tensorflow/hub/blob/1e6dbaeac9e58c93c361202dc00d0dcdebfca879/tensorflow_hub/resolver.py#L62