### PR TITLE
zlib: bump over CVE, use fossils url which is more stable

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,9 +29,9 @@ git_repository(
 http_archive(
     name = "zlib",
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-    sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
-    strip_prefix = "zlib-1.2.12",
-    urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
+    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+    strip_prefix = "zlib-1.2.13",
+    urls = ["https://zlib.net/fossils/zlib-1.2.13.tar.gz"],
 )
 
 # Required by protobuf 3.8.0.


### PR DESCRIPTION
Could you please tell me how to make Bazel use an external zlib? That would
simplify life of package managers.

Thanks.
