### PR TITLE
Removed compat.v2 format

### DIFF
--- a/examples/colab/text_to_video_retrieval_with_s3d_milnce.ipynb
+++ b/examples/colab/text_to_video_retrieval_with_s3d_milnce.ipynb
@@ -70,7 +70,7 @@
         "\n",
         "import os\n",
         "\n",
-        "import tensorflow.compat.v2 as tf\n",
+        "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
         "\n",
         "import numpy as np\n",


### PR DESCRIPTION
Removed compat.v2 format  as they are not required in 2.x version. Atttached [gist](https://colab.sandbox.google.com/gist/mohantym/48b6d8ec8897b4911aadfd3f8bdb80eb/text-to-video-retrieval-with-s3d-mil-nce.ipynb#scrollTo=KdEIAvGgDU5l) for reference.

Thank you!